### PR TITLE
Enhance speed controller for path curvature

### DIFF
--- a/Source/Control/pid_SpeedController.m
+++ b/Source/Control/pid_SpeedController.m
@@ -24,7 +24,7 @@ classdef pid_SpeedController < handle
     %           'Verbose', false);
     %
     %       % In your main loop:
-    %       acceleration = controller.computeAcceleration(currentSpeed, currentTime, turnRadius);
+    %       acceleration = controller.computeAcceleration(currentSpeed, currentTime, turnRadius, upcomingRadii);
     %
     %   Author: [Your Name]
     %   Date:   [Date]
@@ -65,6 +65,10 @@ classdef pid_SpeedController < handle
 
         % ------------------------ Control Flags ---------------------------
         verbose        % Flag to control verbosity of logs
+
+        % -------------------- Speed Profile Props -----------------------
+        speedSmoothing     % Smoothing factor (0-1) for target speed updates
+        currentTargetSpeed % Internally smoothed target speed
     end
 
     methods
@@ -96,6 +100,9 @@ classdef pid_SpeedController < handle
             addParameter(p, 'SMAWindowSize', 5, @(x) isnumeric(x) && x>0 && floor(x)==x);
             addParameter(p, 'GaussianWindowSize', 5, @(x) isnumeric(x) && x>0 && mod(x,2)==1);
             addParameter(p, 'GaussianStd', 1, @(x) isnumeric(x) && x>0);
+
+            % ---- Speed smoothing when updating target speed -----
+            addParameter(p, 'SpeedSmoothing', 0.2, @(x) isnumeric(x) && x>0 && x<=1);
 
             % ---- New parameters for friction-based cornering speed  -----
             addParameter(p, 'FrictionCoeff', 0.7, @(x) isnumeric(x) && x>0 && x<=1);
@@ -132,6 +139,10 @@ classdef pid_SpeedController < handle
             obj.gravity       = p.Results.Gravity;
             obj.safetyFactor  = p.Results.SafetyFactor;
 
+            % Speed smoothing factor and current target speed
+            obj.speedSmoothing     = p.Results.SpeedSmoothing;
+            obj.currentTargetSpeed = desiredSpeed;
+
             % Verbosity flag
             obj.verbose = logical(p.Results.Verbose);
 
@@ -144,28 +155,38 @@ classdef pid_SpeedController < handle
         %  Now accepts an optional 'turnRadius' input. If you have a 
         %  real-time estimate of turn radius, pass it here. If not 
         %  used, you can keep it as `[]` or skip it in calls.
-        function acceleration = computeAcceleration(obj, currentSpeed, currentTime, turnRadius)
+        function acceleration = computeAcceleration(obj, currentSpeed, currentTime, turnRadius, upcomingRadii)
             if nargin < 4 || isempty(turnRadius)
                 % If turnRadius not provided, assume no cornering limit needed
-                turnRadius = Inf; 
+                turnRadius = Inf;
+            end
+            if nargin < 5
+                upcomingRadii = [];
             end
 
             % ---------------- 1) Adjust desired speed for cornering ----------------
             corneringSpeed = obj.computeCorneringSpeed(turnRadius);
-            % Ensure we do not exceed the cornering speed
-            if corneringSpeed < obj.desiredSpeed
-                obj.desiredSpeed = corneringSpeed;
-                if obj.verbose
-                    fprintf('[pid_SpeedController] Reducing desired speed to %.2f m/s due to turn radius = %.2f m\n',...
-                            corneringSpeed, turnRadius);
+            if ~isempty(upcomingRadii)
+                % Use the tightest upcoming radius to further limit speed
+                validR = upcomingRadii(~isinf(upcomingRadii) & ~isnan(upcomingRadii));
+                if ~isempty(validR)
+                    minR = min(validR);
+                else
+                    minR = Inf;
                 end
+                upcomingSpeed = obj.computeCorneringSpeed(minR);
+                corneringSpeed = min(corneringSpeed, upcomingSpeed);
             end
+
+            % Compute smoothed target speed
+            targetSpeed = min(obj.desiredSpeed, corneringSpeed);
+            obj.currentTargetSpeed = obj.currentTargetSpeed + obj.speedSmoothing*(targetSpeed - obj.currentTargetSpeed);
 
             % ---------------- 2) Filter the current speed reading ------------------
             filteredSpeed = obj.applyFilter(currentSpeed);
 
             % ---------------- 3) Check if we need to decelerate --------------------
-            if filteredSpeed > obj.desiredSpeed
+            if filteredSpeed > obj.currentTargetSpeed
                 % Deceleration is required => let the brakes handle it
                 obj.controllerActive = false;
                 acceleration = 0;
@@ -186,7 +207,7 @@ classdef pid_SpeedController < handle
                 filteredSpeed = 0;
             end
 
-            if obj.desiredSpeed <= 0
+            if obj.currentTargetSpeed <= 0
                 % No movement needed
                 acceleration = 0;
                 obj.controllerActive = false;
@@ -197,7 +218,7 @@ classdef pid_SpeedController < handle
             end
 
             % ---------------- 4) PID control for Acceleration ----------------------
-            error = obj.desiredSpeed - filteredSpeed;
+            error = obj.currentTargetSpeed - filteredSpeed;
             dt    = currentTime - obj.previousTime;
             if dt <= 0
                 dt = 1e-6; % Prevent division by zero or negative dt
@@ -288,6 +309,7 @@ classdef pid_SpeedController < handle
             obj.previousError   = 0;
             obj.previousTime    = 0;
             obj.controllerActive = true;
+            obj.currentTargetSpeed = obj.desiredSpeed;
 
             % Reset buffers if needed
             if strcmp(obj.filterType, 'sma')

--- a/Source/Vehicle Model/VehicleModel.m
+++ b/Source/Vehicle Model/VehicleModel.m
@@ -2826,7 +2826,11 @@ classdef VehicleModel < handle
                         desired_acceleration_sim(i) = desired_acceleration;
                         logMessages{end+1} = sprintf('Step %d: Using Excel-provided acceleration: %.4f m/s^2', i, desired_acceleration);
                     else
-                        desired_acceleration = obj.pid_SpeedController.computeAcceleration(currentSpeed, time(i), dynamicsUpdater.forceCalculator.turnRadius);
+                        % Obtain upcoming path geometry for speed planning
+                        curIdx = purePursuitPathFollower.currentWaypointIndex;
+                        lookAhead = min(curIdx + purePursuitPathFollower.planningHorizon - 1, numel(purePursuitPathFollower.radiusOfCurvature));
+                        upcomingRadii = purePursuitPathFollower.radiusOfCurvature(curIdx:lookAhead);
+                        desired_acceleration = obj.pid_SpeedController.computeAcceleration(currentSpeed, time(i), dynamicsUpdater.forceCalculator.turnRadius, upcomingRadii);
                         desired_acceleration_sim(i) = 0;
                         logMessages{end+1} = sprintf('Step %d: Computed acceleration using pid_SpeedController: %.4f m/s^2', i, desired_acceleration);
                     end


### PR DESCRIPTION
## Summary
- smooth target speed with a new smoothing factor
- adjust target speed based on upcoming curvature information
- propagate path curvature data from the vehicle model to the speed controller

## Testing
- `octave --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684418295fe88327b0116bff43f6a418