### PR TITLE
Modify curveSpeedLimiter to trigger for radius under 100m

### DIFF
--- a/Source/Control/curveSpeed_Limiter.m
+++ b/Source/Control/curveSpeed_Limiter.m
@@ -1,14 +1,14 @@
 %{
 % @file curveSpeed_Limiter.m
-% @brief Simple limiter that reduces target speed when a curve is detected.
-%        When a valid turn radius is provided the target speed is scaled
-%        to a fraction of its value.
+% @brief Simple limiter that reduces target speed on tight curves.
+%        The target speed is only reduced when a finite turn radius
+%        below 100 meters is provided.
 %}
 
 classdef curveSpeed_Limiter
     % curveSpeed_Limiter Limit target speed when negotiating curves.
     %   limitedSpeed = obj.limitSpeed(targetSpeed, turnRadius) returns a
-    %   reduced speed whenever turnRadius is finite and positive.
+    %   reduced speed whenever turnRadius is finite, positive and below 100 m.
 
     properties
         reductionFactor (1,1) double {mustBeGreaterThan(reductionFactor,0),mustBeLessThanOrEqual(reductionFactor,1)} = 0.25
@@ -22,7 +22,10 @@ classdef curveSpeed_Limiter
         end
 
         function limitedSpeed = limitSpeed(obj, targetSpeed, turnRadius)
-            if nargin < 3 || isinf(turnRadius) || turnRadius <= 0
+            % limitSpeed Reduces the target speed for tight curves.
+            %   The speed is scaled by the reductionFactor only when the
+            %   provided turnRadius is finite, positive and below 100 m.
+            if nargin < 3 || isinf(turnRadius) || turnRadius <= 0 || turnRadius >= 100
                 limitedSpeed = targetSpeed;
             else
                 limitedSpeed = targetSpeed * obj.reductionFactor;

--- a/tests/CurveSpeedLimiterTest.m
+++ b/tests/CurveSpeedLimiterTest.m
@@ -1,0 +1,17 @@
+function tests = CurveSpeedLimiterTest
+    tests = functiontests(localfunctions);
+end
+
+function testNoLimitForLargeRadius(testCase)
+    limiter = curveSpeed_Limiter(0.5);
+    speed = 20;
+    limited = limiter.limitSpeed(speed, 150); % radius larger than threshold
+    verifyEqual(testCase, limited, speed);
+end
+
+function testLimitForSmallRadius(testCase)
+    limiter = curveSpeed_Limiter(0.5);
+    speed = 20;
+    limited = limiter.limitSpeed(speed, 50); % radius below threshold
+    verifyEqual(testCase, limited, speed * 0.5);
+end


### PR DESCRIPTION
## Summary
- update `curveSpeed_Limiter` so that speed reduction only occurs for
  turn radius below 100 m
- document the new behaviour
- add unit test for the limiter

## Testing
- `octave --eval "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68445721ee6483279bb4d60802216c72