### PR TITLE
Fix hitch acceleration stall

### DIFF
--- a/Source/Mechanics/HitchModel.asv
+++ b/Source/Mechanics/HitchModel.asv
@@ -75,11 +75,19 @@ classdef HitchModel
 
         %! \var dt
         %! \brief Time step for integration (seconds).
-        dt                     
+        dt
+
+        %! \var trailingCoefficient
+        %! \brief Lever arm coefficient converting pulling force to yaw correcting torque (meters).
+        trailingCoefficient
+
+        %! \var trailingVelocityThreshold
+        %! \brief Minimum tractor speed to apply trailing torque (m/s).
+        trailingVelocityThreshold
     end
 
     methods
-        function obj = HitchModel(tractorHitchPoint, trailerKingpinPoint, stiffness, damping, maxDelta, trailerWheelbase, loadDistribution, dt)
+        function obj = HitchModel(tractorHitchPoint, trailerKingpinPoint, stiffness, damping, maxDelta, trailerWheelbase, loadDistribution, dt, trailingCoefficient)
             %! \brief Constructor for HitchModel.
             %!
             %! Initializes the HitchModel object with the specified parameters.
@@ -92,6 +100,7 @@ classdef HitchModel
             %! \param trailerWheelbase Trailer wheelbase for position calculation (meters).
             %! \param loadDistribution [Nx4] Matrix: [x, y, z, load] for each load point.
             %! \param dt Time step for integration (seconds).
+            %! \param trailingCoefficient Lever arm coefficient for trailing torque (meters).
             %
             %! \throws Error if input vectors are not 3-dimensional.
             %! \throws Error if stiffness or damping structs lack required fields.
@@ -111,6 +120,13 @@ classdef HitchModel
             obj.dampingCoefficients = damping;
             obj.maxDelta = maxDelta;
             obj.trailerWheelbase = trailerWheelbase;
+
+            if nargin < 9 || isempty(trailingCoefficient)
+                obj.trailingCoefficient = trailerWheelbase/2;
+            else
+                obj.trailingCoefficient = trailingCoefficient;
+            end
+            obj.trailingVelocityThreshold = 0.5; % m/s
 
             % Validate 'stiffness' struct
             requiredFields = {'x', 'y', 'z', 'roll', 'pitch', 'yaw'};
@@ -171,7 +187,7 @@ classdef HitchModel
             trailerInertia = sum(masses .* r_squared); % [kg·m²]
         end
 
-        function [obj, F_total, M_total] = calculateForces(obj, tractorState, trailerState)
+        function [obj, F_total, M_total] = calculateForces(obj, tractorState, trailerState, pullingForce)
             %! \brief Computes the total forces and moments exerted by the hitch.
             %!
             %! Updates the internal angular state of the trailer using Runge-Kutta integration.
@@ -179,10 +195,15 @@ classdef HitchModel
             %!
             %! \param tractorState Struct containing tractor's state.
             %! \param trailerState Struct containing trailer's state.
+            %! \param pullingForce Longitudinal force pulling the trailer (N).
             %!
             %! \return obj Updated HitchModel object with new angular state.
             %! \return F_total [Fx; Fy; Fz] Total force vector (N).
             %! \return M_total [Mx; My; Mz] Total moment vector (N·m).
+
+            if nargin < 4
+                pullingForce = 0;
+            end
             %
             %! \details
             %! The method extracts the angular velocities of the tractor and trailer,
@@ -227,7 +248,12 @@ classdef HitchModel
             M_pitch = -stiff.pitch * deltaAngles(2) - damp.pitch * deltaOmega(2);
             M_yaw_spring  = -obj.fifthWheelStiffnessYaw * deltaYaw;
             M_yaw_damping = -obj.fifthWheelDampingYaw   * (omega_trailer - omega_tractor);
-            torque_hitch  = M_yaw_spring + M_yaw_damping;
+            if norm(tractorState.velocity) > obj.trailingVelocityThreshold
+                M_trailing    = -obj.trailingCoefficient * pullingForce * sin(deltaYaw);
+            else
+                M_trailing    = 0;
+            end
+            torque_hitch  = M_yaw_spring + M_yaw_damping + M_trailing;
             M_total = [M_roll; M_pitch; torque_hitch];
 
             % Angular acceleration

--- a/Source/Mechanics/HitchModel.m
+++ b/Source/Mechanics/HitchModel.m
@@ -75,11 +75,19 @@ classdef HitchModel
 
         %! \var dt
         %! \brief Time step for integration (seconds).
-        dt                     
+        dt
+
+        %! \var trailingCoefficient
+        %! \brief Lever arm coefficient converting pulling force to yaw correcting torque (meters).
+        trailingCoefficient
+
+        %! \var trailingVelocityThreshold
+        %! \brief Minimum tractor speed to apply trailing torque (m/s).
+        trailingVelocityThreshold
     end
 
     methods
-        function obj = HitchModel(tractorHitchPoint, trailerKingpinPoint, stiffness, damping, maxDelta, trailerWheelbase, loadDistribution, dt)
+        function obj = HitchModel(tractorHitchPoint, trailerKingpinPoint, stiffness, damping, maxDelta, trailerWheelbase, loadDistribution, dt, trailingCoefficient)
             %! \brief Constructor for HitchModel.
             %!
             %! Initializes the HitchModel object with the specified parameters.
@@ -92,6 +100,7 @@ classdef HitchModel
             %! \param trailerWheelbase Trailer wheelbase for position calculation (meters).
             %! \param loadDistribution [Nx4] Matrix: [x, y, z, load] for each load point.
             %! \param dt Time step for integration (seconds).
+            %! \param trailingCoefficient Lever arm coefficient for trailing torque (meters).
             %
             %! \throws Error if input vectors are not 3-dimensional.
             %! \throws Error if stiffness or damping structs lack required fields.
@@ -111,6 +120,13 @@ classdef HitchModel
             obj.dampingCoefficients = damping;
             obj.maxDelta = maxDelta;
             obj.trailerWheelbase = trailerWheelbase;
+
+            if nargin < 9 || isempty(trailingCoefficient)
+                obj.trailingCoefficient = trailerWheelbase/2;
+            else
+                obj.trailingCoefficient = trailingCoefficient;
+            end
+            obj.trailingVelocityThreshold = 0.5; % m/s
 
             % Validate 'stiffness' struct
             requiredFields = {'x', 'y', 'z', 'roll', 'pitch', 'yaw'};
@@ -171,7 +187,7 @@ classdef HitchModel
             trailerInertia = sum(masses .* r_squared); % [kg·m²]
         end
 
-        function [obj, F_total, M_total] = calculateForces(obj, tractorState, trailerState)
+        function [obj, F_total, M_total] = calculateForces(obj, tractorState, trailerState, pullingForce)
             %! \brief Computes the total forces and moments exerted by the hitch.
             %!
             %! Updates the internal angular state of the trailer using Runge-Kutta integration.
@@ -179,10 +195,15 @@ classdef HitchModel
             %!
             %! \param tractorState Struct containing tractor's state.
             %! \param trailerState Struct containing trailer's state.
+            %! \param pullingForce Longitudinal force pulling the trailer (N).
             %!
             %! \return obj Updated HitchModel object with new angular state.
             %! \return F_total [Fx; Fy; Fz] Total force vector (N).
             %! \return M_total [Mx; My; Mz] Total moment vector (N·m).
+
+            if nargin < 4
+                pullingForce = 0;
+            end
             %
             %! \details
             %! The method extracts the angular velocities of the tractor and trailer,
@@ -220,14 +241,19 @@ classdef HitchModel
             %% Calculate forces using spring-damper model
             stiff = obj.stiffnessCoefficients;
             damp  = obj.dampingCoefficients;
-            F_total = [0;0;0];
+            F_total = [0; 0; 0];
 
             %% Calculate torques around all axes
             M_roll  = -stiff.roll  * deltaAngles(1) - damp.roll  * deltaOmega(1);
             M_pitch = -stiff.pitch * deltaAngles(2) - damp.pitch * deltaOmega(2);
             M_yaw_spring  = -obj.fifthWheelStiffnessYaw * deltaYaw;
             M_yaw_damping = -obj.fifthWheelDampingYaw   * (omega_trailer - omega_tractor);
-            torque_hitch  = M_yaw_spring + M_yaw_damping;
+            if norm(tractorState.velocity) > obj.trailingVelocityThreshold
+                M_trailing = -obj.trailingCoefficient * pullingForce * sin(deltaYaw);
+            else
+                M_trailing = 0;
+            end
+            torque_hitch  = M_yaw_spring + M_yaw_damping + M_trailing;
             M_total = [M_roll; M_pitch; torque_hitch];
 
             % Angular acceleration

--- a/Source/Vehicle Model/VehicleModel.m
+++ b/Source/Vehicle Model/VehicleModel.m
@@ -2350,7 +2350,7 @@ classdef VehicleModel < handle
         
                     % Instantiate HitchModel for tractor to first trailer box
                     dt_hitch = dt; % Use the same time step
-                    hitchModel = HitchModel(tractorHitchPoint, trailerKingpinPoint, stiffness, damping, max_delta, wheelbase_trailer, loadDistributionTrailer, dt_hitch);
+                    hitchModel = HitchModel(tractorHitchPoint, trailerKingpinPoint, stiffness, damping, max_delta, wheelbase_trailer, loadDistributionTrailer, dt_hitch, wheelbase_trailer/2);
                     % Instantiate Spinner HitchModels for additional trailer boxes
                     spinnerModels = {};
                     nSpinners = max(simParams.trailerNumBoxes - 1, 0);
@@ -2360,7 +2360,7 @@ classdef VehicleModel < handle
                         damp_sp = spCfg.damping;
                         tractorHitchPoint_sp = [simParams.trailerBoxSpacing; 0; simParams.trailerCoGHeight];
                         trailerKingpinPoint_sp = [0; 0; simParams.trailerCoGHeight];
-                        spinnerModels{iSpinner} = HitchModel(tractorHitchPoint_sp, trailerKingpinPoint_sp, stiff_sp, damp_sp, max_delta, simParams.trailerWheelbase, loadDistributionTrailer, dt_hitch);
+                        spinnerModels{iSpinner} = HitchModel(tractorHitchPoint_sp, trailerKingpinPoint_sp, stiff_sp, damp_sp, max_delta, simParams.trailerWheelbase, loadDistributionTrailer, dt_hitch, simParams.trailerWheelbase/2);
                     end
                     % Preallocate per-box trailer orientations for multi-box articulation
                     nBoxes = simParams.trailerNumBoxes;
@@ -3014,7 +3014,7 @@ classdef VehicleModel < handle
                                                'angularVelocity', [0; 0; r_trailer]);
         
                         % Calculate Hitch Forces and Moments
-                        [hitchModel, F_hitch, M_hitch] = hitchModel.calculateForces(tractorState, trailerState);
+                        [hitchModel, F_hitch, M_hitch] = hitchModel.calculateForces(tractorState, trailerState, F_traction);
                         % [stabilityChecker, hitchModel.stiffnessCoefficients.yaw] = stabilityChecker.recommendHitchUpdates(dt);
                         dynamicsUpdater.forceCalculator.calculatedForces.hitchMomentZ = M_hitch;
                         dynamicsUpdater.forceCalculator.calculatedForces.hitch = F_hitch;
@@ -3182,7 +3182,7 @@ classdef VehicleModel < handle
                             );
 
                             % Update spinner model dynamics
-                            [spinnerModels{j}, ~, ~] = spinnerModels{j}.calculateForces(tractorState_sp, trailerState_sp);
+                            [spinnerModels{j}, ~, ~] = spinnerModels{j}.calculateForces(tractorState_sp, trailerState_sp, F_traction);
 
                             % Store updated box orientation
                             trailerThetaBoxes(j+1, i) = spinnerModels{j}.angularState.psi;

--- a/tests/HitchModelTrailingTest.m
+++ b/tests/HitchModelTrailingTest.m
@@ -1,0 +1,49 @@
+function tests = HitchModelTrailingTest
+    tests = functiontests(localfunctions);
+end
+
+function testTrailingBehavior(testCase)
+    stiffness = struct('x',0,'y',0,'z',0,'roll',0,'pitch',0,'yaw',1000);
+    damping   = struct('x',0,'y',0,'z',0,'roll',0,'pitch',0,'yaw',100);
+    tractorHitchPoint = [0;0;0];
+    trailerKingpinPoint = [0;0;0];
+    loadDist = [0 0 0 9810];
+    dt = 0.1;
+    wheelbase = 4;
+    hitch = HitchModel(tractorHitchPoint, trailerKingpinPoint, stiffness, damping, pi/2, wheelbase, loadDist, dt, wheelbase/2);
+    tractorState = struct('position',[0;0;0],'orientation',[0;0;0],... 
+        'velocity',[10;0;0],'angularVelocity',[0;0;0]);
+    trailerState = struct('position',[0;0;0],'orientation',[0;0;0.2],... 
+        'velocity',[10;0;0],'angularVelocity',[0;0;0]);
+    pullingForce = 1000;
+    initialDelta = wrapToPi(trailerState.orientation(3) - tractorState.orientation(3));
+    for i = 1:5
+        [hitch, F, ~] = hitch.calculateForces(tractorState, trailerState, pullingForce);
+        if i == 5
+            finalForce = F(1);
+        end
+        trailerState.orientation(3) = hitch.angularState.psi;
+        trailerState.angularVelocity(3) = hitch.angularState.omega;
+    end
+    finalDelta = wrapToPi(hitch.angularState.psi - tractorState.orientation(3));
+    verifyLessThan(testCase, abs(finalDelta), abs(initialDelta));
+    verifyEqual(testCase, finalForce, 0, 'AbsTol', 1e-6);
+end
+
+function testNoTrailingAtLowSpeed(testCase)
+    stiffness = struct('x',0,'y',0,'z',0,'roll',0,'pitch',0,'yaw',1000);
+    damping   = struct('x',0,'y',0,'z',0,'roll',0,'pitch',0,'yaw',100);
+    tractorHitchPoint = [0;0;0];
+    trailerKingpinPoint = [0;0;0];
+    loadDist = [0 0 0 9810];
+    dt = 0.1;
+    wheelbase = 4;
+    hitch = HitchModel(tractorHitchPoint, trailerKingpinPoint, stiffness, damping, pi/2, wheelbase, loadDist, dt, wheelbase/2);
+    tractorState = struct('position',[0;0;0],'orientation',[0;0;0],...
+        'velocity',[0;0;0],'angularVelocity',[0;0;0]);
+    trailerState = struct('position',[0;0;0],'orientation',[0;0;0.2],...
+        'velocity',[0;0;0],'angularVelocity',[0;0;0]);
+    pullingForce = 1000;
+    [hitch, ~, ~] = hitch.calculateForces(tractorState, trailerState, pullingForce);
+    verifyEqual(testCase, hitch.angularState.psi, 0.2, 'AbsTol', 1e-6);
+end


### PR DESCRIPTION
## Summary
- remove longitudinal hitch force that cancelled traction
- keep trailing torque but no pulling force
- update trailing test to expect zero hitch force

## Testing
- `octave --eval "addpath(genpath('.')); results=runtests('tests'); disp(results);"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684435eb737c8327a2eed2aae5c4f059