### PR TITLE
Add curve speed limiter class

### DIFF
--- a/Source/Control/curveSpeed_Limiter.m
+++ b/Source/Control/curveSpeed_Limiter.m
@@ -1,50 +1,77 @@
 %{
  @file curveSpeed_Limiter.m
- @brief Limits commanded speed when approaching a curve by ramping
-        from the current target speed down to a reduced value based on
-        stopping distance.
+ @brief Limits commanded speed when approaching a curve.
+        Ramps the target speed down to a fraction of the PID commanded
+        speed as the vehicle gets within a specified time to a curve
+        and ramps it back up smoothly after the curve.
 %}
 
 classdef curveSpeed_Limiter < handle
     properties
-        % Reduction factor applied at the start of the curve (0-1)
+        % Reduction factor applied at the centre of the curve (0-1)
         reductionFactor
-        % Maximum comfortable deceleration magnitude (m/s^2)
-        maxDecel
+        % Time in seconds to ramp from full speed to the reduced speed
+        rampDownTime
+        % Maximum acceleration used when ramping back up (m/s^2)
+        maxAccel
+
+        % Internal state: current reduction multiplier (0-1)
+        currentFactor
     end
 
     methods
-        function obj = curveSpeed_Limiter(reductionFactor, maxDecel)
+        function obj = curveSpeed_Limiter(reductionFactor, rampDownTime, maxAccel)
             if nargin < 1 || isempty(reductionFactor)
                 reductionFactor = 0.75; % 25% reduction
             end
-            if nargin < 2 || isempty(maxDecel)
-                maxDecel = 5; % default deceleration
+            if nargin < 2 || isempty(rampDownTime)
+                rampDownTime = 5.5; % seconds
             end
+            if nargin < 3 || isempty(maxAccel)
+                maxAccel = 2; % m/s^2 for ramp up
+            end
+
             obj.reductionFactor = reductionFactor;
-            obj.maxDecel = maxDecel;
+            obj.rampDownTime    = rampDownTime;
+            obj.maxAccel        = maxAccel;
+            obj.currentFactor   = 1.0;
         end
 
-        function limitedSpeed = limitSpeed(obj, currentSpeed, targetSpeed, distToCurve)
-            if nargin < 4
-                error('limitSpeed requires current speed, target speed and distance to curve start.');
-            end
-            stopDist = obj.computeStoppingDistance(currentSpeed, targetSpeed * obj.reductionFactor);
-            if distToCurve >= stopDist || stopDist <= 0
-                limitedSpeed = targetSpeed;
-            else
-                ratio = max(0, min(1, distToCurve / stopDist));
-                rampFactor = obj.reductionFactor + (1 - obj.reductionFactor) * ratio;
-                limitedSpeed = targetSpeed * rampFactor;
-            end
-        end
+        function limitedSpeed = limitSpeed(obj, currentSpeed, targetSpeed, distToCurve, inCurve, dt)
+            % limitSpeed Applies ramping to the target speed based on distance
+            % to the upcoming curve and whether the vehicle is currently in a
+            % curve.
+            %
+            % Parameters:
+            %   currentSpeed - Current vehicle speed (m/s)
+            %   targetSpeed  - PID commanded speed (m/s)
+            %   distToCurve  - Distance to the start of the next curve (m)
+            %   inCurve      - Logical flag indicating if the vehicle is in a curve
+            %   dt           - Timestep of the simulation (s)
 
-        function dist = computeStoppingDistance(obj, v0, v1)
-            if v0 <= v1
-                dist = 0;
-            else
-                dist = (v0^2 - v1^2) / (2 * obj.maxDecel);
+            if nargin < 5
+                error('limitSpeed requires current speed, target speed, distance to curve and curve flag.');
             end
+            if nargin < 6
+                dt = 0.01; % default small timestep
+            end
+
+            if inCurve
+                obj.currentFactor = obj.reductionFactor;
+            else
+                timeToCurve = distToCurve / max(currentSpeed, eps);
+                if timeToCurve <= obj.rampDownTime && distToCurve >= 0
+                    factor = obj.reductionFactor + ...
+                        (1 - obj.reductionFactor) * (timeToCurve / obj.rampDownTime);
+                    obj.currentFactor = min(obj.currentFactor, factor);
+                else
+                    % Ramp up towards 1 using maxAccel constraint
+                    rate = obj.maxAccel * dt / max(targetSpeed, eps);
+                    obj.currentFactor = min(1, obj.currentFactor + rate);
+                end
+            end
+
+            limitedSpeed = targetSpeed * obj.currentFactor;
         end
     end
 end

--- a/Source/Control/curveSpeed_Limiter.m
+++ b/Source/Control/curveSpeed_Limiter.m
@@ -1,0 +1,50 @@
+%{
+ @file curveSpeed_Limiter.m
+ @brief Limits commanded speed when approaching a curve by ramping
+        from the current target speed down to a reduced value based on
+        stopping distance.
+%}
+
+classdef curveSpeed_Limiter < handle
+    properties
+        % Reduction factor applied at the start of the curve (0-1)
+        reductionFactor
+        % Maximum comfortable deceleration magnitude (m/s^2)
+        maxDecel
+    end
+
+    methods
+        function obj = curveSpeed_Limiter(reductionFactor, maxDecel)
+            if nargin < 1 || isempty(reductionFactor)
+                reductionFactor = 0.75; % 25% reduction
+            end
+            if nargin < 2 || isempty(maxDecel)
+                maxDecel = 5; % default deceleration
+            end
+            obj.reductionFactor = reductionFactor;
+            obj.maxDecel = maxDecel;
+        end
+
+        function limitedSpeed = limitSpeed(obj, currentSpeed, targetSpeed, distToCurve)
+            if nargin < 4
+                error('limitSpeed requires current speed, target speed and distance to curve start.');
+            end
+            stopDist = obj.computeStoppingDistance(currentSpeed, targetSpeed * obj.reductionFactor);
+            if distToCurve >= stopDist || stopDist <= 0
+                limitedSpeed = targetSpeed;
+            else
+                ratio = max(0, min(1, distToCurve / stopDist));
+                rampFactor = obj.reductionFactor + (1 - obj.reductionFactor) * ratio;
+                limitedSpeed = targetSpeed * rampFactor;
+            end
+        end
+
+        function dist = computeStoppingDistance(obj, v0, v1)
+            if v0 <= v1
+                dist = 0;
+            else
+                dist = (v0^2 - v1^2) / (2 * obj.maxDecel);
+            end
+        end
+    end
+end

--- a/tests/CurveSpeedLimiterTest.m
+++ b/tests/CurveSpeedLimiterTest.m
@@ -2,12 +2,12 @@ function tests = CurveSpeedLimiterTest
     tests = functiontests(localfunctions);
 end
 
-function testNoRampBeforeStoppingDistance(testCase)
+function testNoReductionWhenFar(testCase)
     limiter = curveSpeed_Limiter();
     curSpeed = 20;
     tgtSpeed = 20;
-    stopDist = limiter.computeStoppingDistance(curSpeed, tgtSpeed * limiter.reductionFactor);
-    limited = limiter.limitSpeed(curSpeed, tgtSpeed, stopDist + 1);
+    dist = curSpeed * (limiter.rampDownTime + 1); % More than ramp time ahead
+    limited = limiter.limitSpeed(curSpeed, tgtSpeed, dist, false, 0.1);
     verifyEqual(testCase, limited, tgtSpeed, 'AbsTol', 1e-10);
 end
 
@@ -15,7 +15,7 @@ function testFullReductionAtCurveStart(testCase)
     limiter = curveSpeed_Limiter();
     curSpeed = 20;
     tgtSpeed = 20;
-    limited = limiter.limitSpeed(curSpeed, tgtSpeed, 0);
+    limited = limiter.limitSpeed(curSpeed, tgtSpeed, 0, true, 0.1);
     verifyEqual(testCase, limited, tgtSpeed * limiter.reductionFactor, 'AbsTol', 1e-10);
 end
 
@@ -23,8 +23,19 @@ function testHalfwayReduction(testCase)
     limiter = curveSpeed_Limiter();
     curSpeed = 20;
     tgtSpeed = 20;
-    stopDist = limiter.computeStoppingDistance(curSpeed, tgtSpeed * limiter.reductionFactor);
-    limited = limiter.limitSpeed(curSpeed, tgtSpeed, stopDist/2);
+    dist = curSpeed * limiter.rampDownTime / 2;
+    limited = limiter.limitSpeed(curSpeed, tgtSpeed, dist, false, 0.1);
     expected = tgtSpeed * (limiter.reductionFactor + (1 - limiter.reductionFactor) * 0.5);
     verifyEqual(testCase, limited, expected, 'AbsTol', 1e-10);
+end
+
+function testRampUpAfterCurve(testCase)
+    limiter = curveSpeed_Limiter();
+    curSpeed = 20; tgtSpeed = 20;
+    % Inside curve first
+    limiter.limitSpeed(curSpeed, tgtSpeed, 0, true, 0.1);
+    % Exit curve
+    limited = limiter.limitSpeed(curSpeed, tgtSpeed, Inf, false, 1.0);
+    expectedFactor = limiter.reductionFactor + limiter.maxAccel * 1.0 / tgtSpeed;
+    verifyEqual(testCase, limited, tgtSpeed * expectedFactor, 'AbsTol', 1e-10);
 end

--- a/tests/CurveSpeedLimiterTest.m
+++ b/tests/CurveSpeedLimiterTest.m
@@ -2,16 +2,29 @@ function tests = CurveSpeedLimiterTest
     tests = functiontests(localfunctions);
 end
 
-function testNoLimitForLargeRadius(testCase)
-    limiter = curveSpeed_Limiter(0.5);
-    speed = 20;
-    limited = limiter.limitSpeed(speed, 150); % radius larger than threshold
-    verifyEqual(testCase, limited, speed);
+function testNoRampBeforeStoppingDistance(testCase)
+    limiter = curveSpeed_Limiter();
+    curSpeed = 20;
+    tgtSpeed = 20;
+    stopDist = limiter.computeStoppingDistance(curSpeed, tgtSpeed * limiter.reductionFactor);
+    limited = limiter.limitSpeed(curSpeed, tgtSpeed, stopDist + 1);
+    verifyEqual(testCase, limited, tgtSpeed, 'AbsTol', 1e-10);
 end
 
-function testLimitForSmallRadius(testCase)
-    limiter = curveSpeed_Limiter(0.5);
-    speed = 20;
-    limited = limiter.limitSpeed(speed, 50); % radius below threshold
-    verifyEqual(testCase, limited, speed * 0.5);
+function testFullReductionAtCurveStart(testCase)
+    limiter = curveSpeed_Limiter();
+    curSpeed = 20;
+    tgtSpeed = 20;
+    limited = limiter.limitSpeed(curSpeed, tgtSpeed, 0);
+    verifyEqual(testCase, limited, tgtSpeed * limiter.reductionFactor, 'AbsTol', 1e-10);
+end
+
+function testHalfwayReduction(testCase)
+    limiter = curveSpeed_Limiter();
+    curSpeed = 20;
+    tgtSpeed = 20;
+    stopDist = limiter.computeStoppingDistance(curSpeed, tgtSpeed * limiter.reductionFactor);
+    limited = limiter.limitSpeed(curSpeed, tgtSpeed, stopDist/2);
+    expected = tgtSpeed * (limiter.reductionFactor + (1 - limiter.reductionFactor) * 0.5);
+    verifyEqual(testCase, limited, expected, 'AbsTol', 1e-10);
 end


### PR DESCRIPTION
## Summary
- add `curveSpeed_Limiter` class to smoothly reduce speed before curves
- update curve speed limiter unit tests for new ramping behavior

## Testing
- `octave` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_b_68449266d52883279e598bb99fe0f77d