### PR TITLE
Add stopping-distance logic to curve speed limiter

### DIFF
--- a/Source/Control/curveSpeed_Limiter.m
+++ b/Source/Control/curveSpeed_Limiter.m
@@ -1,0 +1,117 @@
+%{
+ @file curveSpeed_Limiter.m
+ @brief Limits commanded speed when approaching a curve.
+        Applies a predefined deceleration profile when approaching a
+        curve: -1 m/s^2 for 0.5 s followed by -4.5 m/s^2 for 1 s.
+        After the curve it ramps the speed back up using +6 m/s^2.
+%}
+
+classdef curveSpeed_Limiter < handle
+    properties
+        % Reduction factor applied at the centre of the curve (0-1)
+        reductionFactor
+        % Time in seconds prior to a curve when ramping begins
+        rampDownTime
+        % Maximum acceleration used when ramping back up (m/s^2)
+        rampUpAccel
+
+        % Internal state: current reduction multiplier (0-1)
+        currentFactor
+    end
+
+    methods
+        function obj = curveSpeed_Limiter(reductionFactor, rampDownTime, rampUpAccel)
+            if nargin < 1 || isempty(reductionFactor)
+                reductionFactor = 0.75; % 25% reduction
+            end
+            if nargin < 2 || isempty(rampDownTime)
+                rampDownTime = 1.5; % seconds (0.5s at -1 m/s^2, 1s at -4.5 m/s^2)
+            end
+            if nargin < 3 || isempty(rampUpAccel)
+                rampUpAccel = 6; % m/s^2 for ramp up phase
+            end
+
+            obj.reductionFactor = reductionFactor;
+            obj.rampDownTime    = rampDownTime;
+            obj.rampUpAccel     = rampUpAccel;
+            obj.currentFactor   = 1.0;
+        end
+
+        function [dist, time] = stoppingDistance(obj, speed)
+            % stoppingDistance  Calculate distance and time needed to reduce
+            % speed to reductionFactor * speed using the deceleration profile.
+
+            if nargin < 2
+                speed = 0;
+            end
+
+            acc1 = 1;      % m/s^2 for the first 0.5 s
+            t1max = 0.5;   % seconds
+            acc2 = 4.5;    % m/s^2 for the next 1 s
+            t2max = 1.0;   % seconds
+
+            deltaV = speed * (1 - obj.reductionFactor);
+
+            if deltaV <= acc1 * t1max
+                t1 = deltaV / acc1;
+                dist = speed * t1 - 0.5 * acc1 * t1^2;
+                time = t1;
+                return;
+            end
+
+            t1 = t1max;
+            v1 = speed - acc1 * t1;
+            dist1 = speed * t1 - 0.5 * acc1 * t1^2;
+
+            remaining = deltaV - acc1 * t1;
+            t2 = min(remaining / acc2, t2max);
+            dist2 = v1 * t2 - 0.5 * acc2 * t2^2;
+
+            dist = dist1 + dist2;
+            time = t1 + t2;
+        end
+
+        function limitedSpeed = limitSpeed(obj, currentSpeed, targetSpeed, distToCurve, inCurve, dt)
+            % limitSpeed Applies ramping to the target speed based on distance
+            % to the upcoming curve and whether the vehicle is currently in a
+            % curve.
+            %
+            % Parameters:
+            %   currentSpeed - Current vehicle speed (m/s)
+            %   targetSpeed  - PID commanded speed (m/s)
+            %   distToCurve  - Distance to the start of the next curve (m)
+            %   inCurve      - Logical flag indicating if the vehicle is in a curve
+            %   dt           - Timestep of the simulation (s)
+
+            if nargin < 5
+                error('limitSpeed requires current speed, target speed, distance to curve and curve flag.');
+            end
+            if nargin < 6
+                dt = 0.01; % default small timestep
+            end
+
+            if inCurve
+                obj.currentFactor = obj.reductionFactor;
+            else
+                [stopDist, rampTime] = obj.stoppingDistance(targetSpeed);
+                timeToCurve = distToCurve / max(currentSpeed, eps);
+                if distToCurve <= stopDist && distToCurve >= 0
+                    elapsed = max(0, rampTime - timeToCurve);
+                    if elapsed <= 0.5
+                        deltaV = 1 * elapsed;
+                    else
+                        deltaV = 1 * 0.5 + 4.5 * min(elapsed - 0.5, 1.0);
+                    end
+                    factor = 1 - deltaV / max(targetSpeed, eps);
+                    factor = max(obj.reductionFactor, min(1, factor));
+                    obj.currentFactor = min(obj.currentFactor, factor);
+                else
+                    rate = obj.rampUpAccel * dt / max(targetSpeed, eps);
+                    obj.currentFactor = min(1, obj.currentFactor + rate);
+                end
+            end
+
+            limitedSpeed = targetSpeed * obj.currentFactor;
+        end
+    end
+end

--- a/tests/CurveSpeedLimiterTest.m
+++ b/tests/CurveSpeedLimiterTest.m
@@ -2,16 +2,56 @@ function tests = CurveSpeedLimiterTest
     tests = functiontests(localfunctions);
 end
 
-function testNoLimitForLargeRadius(testCase)
-    limiter = curveSpeed_Limiter(0.5);
-    speed = 20;
-    limited = limiter.limitSpeed(speed, 150); % radius larger than threshold
-    verifyEqual(testCase, limited, speed);
+function testNoReductionWhenFar(testCase)
+    limiter = curveSpeed_Limiter();
+    curSpeed = 20;
+    tgtSpeed = 20;
+    [stopDist, ~] = limiter.stoppingDistance(tgtSpeed);
+    dist = stopDist + 10; % Well beyond required distance
+    limited = limiter.limitSpeed(curSpeed, tgtSpeed, dist, false, 0.1);
+    verifyEqual(testCase, limited, tgtSpeed, 'AbsTol', 1e-10);
 end
 
-function testLimitForSmallRadius(testCase)
-    limiter = curveSpeed_Limiter(0.5);
+function testFullReductionAtCurveStart(testCase)
+    limiter = curveSpeed_Limiter();
+    curSpeed = 20;
+    tgtSpeed = 20;
+    limited = limiter.limitSpeed(curSpeed, tgtSpeed, 0, true, 0.1);
+    verifyEqual(testCase, limited, tgtSpeed * limiter.reductionFactor, 'AbsTol', 1e-10);
+end
+
+function testHalfwayReduction(testCase)
+    limiter = curveSpeed_Limiter();
+    curSpeed = 20;
+    tgtSpeed = 20;
+    [~, rampTime] = limiter.stoppingDistance(tgtSpeed);
+    dist = curSpeed * rampTime / 2;
+    limited = limiter.limitSpeed(curSpeed, tgtSpeed, dist, false, 0.1);
+    % Expected based on piecewise deceleration profile
+    deltaV = 1 * 0.5 + 4.5 * (1.0 - 0.75);
+    expectedFactor = 1 - deltaV / tgtSpeed;
+    expectedFactor = max(limiter.reductionFactor, min(1, expectedFactor));
+    expected = tgtSpeed * expectedFactor;
+    verifyEqual(testCase, limited, expected, 'AbsTol', 1e-10);
+end
+
+function testRampUpAfterCurve(testCase)
+    limiter = curveSpeed_Limiter();
+    curSpeed = 20; tgtSpeed = 20;
+    % Inside curve first
+    limiter.limitSpeed(curSpeed, tgtSpeed, 0, true, 0.1);
+    % Exit curve
+    limited = limiter.limitSpeed(curSpeed, tgtSpeed, Inf, false, 1.0);
+    expectedFactor = min(1, limiter.reductionFactor + limiter.rampUpAccel * 1.0 / tgtSpeed);
+    verifyEqual(testCase, limited, tgtSpeed * expectedFactor, 'AbsTol', 1e-10);
+end
+
+function testStoppingDistanceComputation(testCase)
+    limiter = curveSpeed_Limiter();
     speed = 20;
-    limited = limiter.limitSpeed(speed, 50); % radius below threshold
-    verifyEqual(testCase, limited, speed * 0.5);
+    [dist, time] = limiter.stoppingDistance(speed);
+    expTime = 1.5;
+    expDist = 9.875 + 17.25;
+    verifyEqual(testCase, time, expTime, 'AbsTol', 1e-10);
+    verifyEqual(testCase, dist, expDist, 'AbsTol', 1e-10);
 end


### PR DESCRIPTION
## Summary
- expand `curveSpeed_Limiter` with a `stoppingDistance` method
- start deceleration based on the computed stopping distance
- update unit tests for new API and add coverage for stopping distance

## Testing
- `octave --eval "addpath('Source/Control'); addpath('tests'); CurveSpeedLimiterTest"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68449266d52883279e598bb99fe0f77d