### PR TITLE
Fix multi-trailer box alignment

### DIFF
--- a/Source/Mechanics/HitchModel.m
+++ b/Source/Mechanics/HitchModel.m
@@ -169,9 +169,27 @@ classdef HitchModel
             obj.trailerInertia = obj.calculateTrailerInertia();
 
             % Initialize angular state
-            obj.angularState.psi = 0;     % Initial yaw angle
-            obj.angularState.omega = 0;   % Initial yaw rate
-            obj.dt = dt;                  % Time step for integration
+        obj.angularState.psi = 0;     % Initial yaw angle
+        obj.angularState.omega = 0;   % Initial yaw rate
+        obj.dt = dt;                  % Time step for integration
+        end
+
+        function obj = initializeState(obj, psi, omega)
+            %INITIALIZESTATE Set initial yaw angle and rate for the hitch model.
+            %   OBJ = INITIALIZESTATE(OBJ, PSI, OMEGA) sets the internal
+            %   angular state of the hitch to the provided yaw angle PSI and yaw
+            %   rate OMEGA. If omitted, PSI defaults to 0 and OMEGA defaults to
+            %   0.
+
+            if nargin < 2 || isempty(psi)
+                psi = 0;
+            end
+            if nargin < 3 || isempty(omega)
+                omega = 0;
+            end
+
+            obj.angularState.psi = psi;
+            obj.angularState.omega = omega;
         end
 
         function trailerInertia = calculateTrailerInertia(obj)

--- a/Source/Vehicle Model/VehicleModel.m
+++ b/Source/Vehicle Model/VehicleModel.m
@@ -2364,6 +2364,8 @@ classdef VehicleModel < handle
                     % Instantiate HitchModel for tractor to first trailer box
                     dt_hitch = dt; % Use the same time step
                     hitchModel = HitchModel(tractorHitchPoint, trailerKingpinPoint, stiffness, damping, max_delta, wheelbase_trailer, loadDistributionTrailer, dt_hitch);
+                    % Align initial hitch orientation with trailer
+                    hitchModel = hitchModel.initializeState(psi_trailer, 0);
                     % Instantiate Spinner HitchModels for additional trailer boxes
                     spinnerModels = {};
                     nSpinners = max(simParams.trailerNumBoxes - 1, 0);
@@ -2374,6 +2376,8 @@ classdef VehicleModel < handle
                         tractorHitchPoint_sp = [simParams.trailerBoxSpacing; 0; simParams.trailerCoGHeight];
                         trailerKingpinPoint_sp = [0; 0; simParams.trailerCoGHeight];
                         spinnerModels{iSpinner} = HitchModel(tractorHitchPoint_sp, trailerKingpinPoint_sp, stiff_sp, damp_sp, max_delta, simParams.trailerWheelbase, loadDistributionTrailer, dt_hitch);
+                        % Ensure additional boxes start aligned
+                        spinnerModels{iSpinner} = spinnerModels{iSpinner}.initializeState(psi_trailer, 0);
                     end
                     % Preallocate per-box trailer orientations for multi-box articulation
                     nBoxes = simParams.trailerNumBoxes;

--- a/tests/HitchModelTrailingTest.m
+++ b/tests/HitchModelTrailingTest.m
@@ -43,3 +43,17 @@ function testNoTrailingAtLowSpeed(testCase)
     [hitch, ~, ~] = hitch.calculateForces(tractorState, trailerState, pullingForce);
     verifyEqual(testCase, hitch.angularState.psi, 0.2, 'AbsTol', 1e-6);
 end
+
+function testInitializeState(testCase)
+    stiffness = struct('x',0,'y',0,'z',0,'roll',0,'pitch',0,'yaw',1000);
+    damping   = struct('x',0,'y',0,'z',0,'roll',0,'pitch',0,'yaw',100);
+    tractorHitchPoint = [0;0;0];
+    trailerKingpinPoint = [0;0;0];
+    loadDist = [0 0 0 9810];
+    dt = 0.1;
+    wheelbase = 4;
+    hitch = HitchModel(tractorHitchPoint, trailerKingpinPoint, stiffness, damping, pi/2, wheelbase, loadDist, dt, wheelbase/2);
+    hitch = hitch.initializeState(0.3, 0.05);
+    verifyEqual(testCase, hitch.angularState.psi, 0.3, 'AbsTol', 1e-12);
+    verifyEqual(testCase, hitch.angularState.omega, 0.05, 'AbsTol', 1e-12);
+end


### PR DESCRIPTION
## Summary
- add `initializeState` helper to `HitchModel`
- initialize hitch and spinner models so all trailer boxes start aligned
- add regression test for the new initialization helper

## Testing
- `octave --eval "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6844b130303083278447b6337b9d1245