### PR TITLE
Improve ACC controller logic

### DIFF
--- a/Source/Control/acc_Controller.m
+++ b/Source/Control/acc_Controller.m
@@ -1,0 +1,86 @@
+classdef acc_Controller < handle
+    % ACC Controller that modulates acceleration output from a PID controller
+    % when approaching a curve. It reduces speed to a fraction of the
+    % approach speed and predicts trailer rotation assuming simple bicycle
+    % model kinematics. Deceleration begins when the vehicle is within a
+    % configurable time of the next curve, determined via map localization.
+
+    properties
+        speedReduction (1,1) double {mustBePositive} = 0.75
+        maxDecel (1,1) double {mustBePositive} = 2.0
+        trailerLength (1,1) double {mustBeNonnegative} = 12.0
+        wheelbase (1,1) double {mustBePositive} = 3.0
+        decelLookaheadTime (1,1) double {mustBePositive} = 5.5
+    end
+
+    properties(Access=private)
+        decelActive(1,1) logical = false
+        baseSpeed(1,1) double = NaN
+    end
+
+    methods
+        function obj = acc_Controller(speedReduction, maxDecel, trailerLength, wheelbase, lookaheadTime)
+            if nargin >= 1 && ~isempty(speedReduction); obj.speedReduction = speedReduction; end
+            if nargin >= 2 && ~isempty(maxDecel); obj.maxDecel = maxDecel; end
+            if nargin >= 3 && ~isempty(trailerLength); obj.trailerLength = trailerLength; end
+            if nargin >= 4 && ~isempty(wheelbase); obj.wheelbase = wheelbase; end
+            if nargin >= 5 && ~isempty(lookaheadTime); obj.decelLookaheadTime = lookaheadTime; end
+        end
+
+        function [accelOut, predictedRotation] = adjust(obj, currentSpeed, pidAccel, distToCurve, turnRadius, dt)
+            if nargin < 5 || isempty(turnRadius)
+                turnRadius = inf;
+            end
+            if nargin < 6
+                dt = 0.01;
+            end
+
+            if ~obj.decelActive
+                obj.baseSpeed = currentSpeed; % remember speed before decel
+            end
+
+            decel = max(obj.maxDecel, -pidAccel); % use pid accel if stronger braking
+            targetSpeed = obj.speedReduction * obj.baseSpeed;
+
+            triggerDist = currentSpeed * obj.decelLookaheadTime;
+            if distToCurve <= triggerDist
+                obj.decelActive = true;
+            elseif isinf(turnRadius)
+                % reset when road straightens and far from curve
+                obj.decelActive = false;
+            end
+
+            if obj.decelActive
+                if currentSpeed > targetSpeed
+                    accelOut = -decel;
+                elseif currentSpeed < targetSpeed
+                    accelOut = max(pidAccel, 0); % do not accelerate above target
+                else
+                    accelOut = 0;
+                end
+            else
+                accelOut = pidAccel;
+            end
+
+            if isinf(turnRadius)
+                predictedRotation = 0;
+            else
+                predictedRotation = currentSpeed * dt / turnRadius * (obj.trailerLength / obj.wheelbase);
+            end
+        end
+    end
+
+    methods(Access=private)
+        function dist = computeStoppingDistance(~, v0, v1, decel)
+            if decel <= 0
+                dist = inf;
+                return;
+            end
+            if v0 <= v1
+                dist = 0;
+            else
+                dist = (v0^2 - v1^2) / (2*decel);
+            end
+        end
+    end
+end

--- a/Source/Simulation/VehicleLocalizer.m
+++ b/Source/Simulation/VehicleLocalizer.m
@@ -1,0 +1,49 @@
+classdef VehicleLocalizer < handle
+    % VehicleLocalizer Localizes vehicle position on a map and provides
+    % distance to the next curve along the path.
+
+    properties
+        waypoints
+        waypointSpacing (1,1) double = 1.0
+    end
+
+    methods
+        function obj = VehicleLocalizer(waypoints, spacing)
+            if nargin >= 1 && ~isempty(waypoints)
+                if iscell(waypoints)
+                    waypoints = cell2mat(waypoints);
+                end
+                obj.waypoints = double(waypoints);
+            else
+                obj.waypoints = zeros(0,2);
+            end
+            if nargin >= 2 && ~isempty(spacing)
+                obj.waypointSpacing = spacing;
+            end
+        end
+
+        function idx = localize(obj, position)
+            %LOCALIZE Returns the closest waypoint index to the given position.
+            if isempty(obj.waypoints)
+                idx = 1;
+                return;
+            end
+            posVec = double(position(:)');
+            if numel(posVec) > 2
+                posVec = posVec(1:2);
+            end
+            diffs = obj.waypoints(:,1:2) - posVec;
+            [~, idx] = min(sum(diffs.^2, 2));
+        end
+
+        function dist = distanceToNextCurve(obj, currentIdx, upcomingRadii)
+            %DISTANCETONEXTCURVE Compute distance to first upcoming non-infinite radius
+            curveIdx = find(~isinf(upcomingRadii), 1, 'first');
+            if isempty(curveIdx)
+                dist = Inf;
+            else
+                dist = (curveIdx-1) * obj.waypointSpacing;
+            end
+        end
+    end
+end

--- a/Source/Vehicle Model/VehicleModel.m
+++ b/Source/Vehicle Model/VehicleModel.m
@@ -19,6 +19,8 @@ classdef VehicleModel < handle
         limiter_LateralControl   % Instance of limiter_LateralControl
         limiter_LongitudinalControl  % Instance of limiter_LongitudinalControl
         jerkController              % Instance of jerk_Controller for jerk limiting
+        accController               % Instance of acc_Controller for ACC
+        localizer                  % Instance of VehicleLocalizer for map-based localization
         % curveSpeedLimiter           % Instance of curveSpeed_Limiter
         simulationName
         uiManager
@@ -1784,6 +1786,8 @@ classdef VehicleModel < handle
                     gaussianStd ...
                     );
                 obj.jerkController = jerk_Controller(0.7 * 9.81);
+                obj.accController = acc_Controller(0.75, 2.0, simParams.trailerLength, tractorWheelbase, 5.5);
+                obj.localizer = VehicleLocalizer(simParams.waypoints, 1.0);
                 logMessages{end+1} = 'limiter_LongitudinalControl initialized successfully.';
                 % --- End of limiter_LongitudinalControl Initialization ---
 
@@ -2841,7 +2845,7 @@ classdef VehicleModel < handle
                         logMessages{end+1} = sprintf('Step %d: Using Excel-provided acceleration: %.4f m/s^2', i, desired_acceleration);
                     else
                         % Obtain upcoming path geometry for speed planning
-                        curIdx = purePursuitPathFollower.currentWaypointIndex;
+                        curIdx = obj.localizer.localize(dynamicsUpdater.position');
                         lookAhead = min(curIdx + purePursuitPathFollower.planningHorizon - 1, numel(purePursuitPathFollower.radiusOfCurvature));
                         upcomingRadii = purePursuitPathFollower.radiusOfCurvature(curIdx:lookAhead);
                         % waypointSpacing = 1.0;
@@ -2855,7 +2859,10 @@ classdef VehicleModel < handle
                         % baseSpeed = obj.pid_SpeedController.desiredSpeed;
                         % [limitedSpeed, accelOverride] = obj.curveSpeedLimiter.limitSpeed(currentSpeed, baseSpeed, distToCurve, inCurve, dt);
                         % obj.pid_SpeedController.desiredSpeed = limitedSpeed;
-                        desired_acceleration = obj.pid_SpeedController.computeAcceleration(currentSpeed, time(i), dynamicsUpdater.forceCalculator.turnRadius, upcomingRadii);
+                        desired_acceleration_pid = obj.pid_SpeedController.computeAcceleration(currentSpeed, time(i), dynamicsUpdater.forceCalculator.turnRadius, upcomingRadii);
+                        distToCurve = obj.localizer.distanceToNextCurve(curIdx, upcomingRadii);
+                        [desired_acceleration, predictedRotation] = obj.accController.adjust(currentSpeed, desired_acceleration_pid, distToCurve, dynamicsUpdater.forceCalculator.turnRadius, dt);
+                        logMessages{end+1} = sprintf('Step %d: ACC predicted trailer rotation %.4f rad.', i, predictedRotation);
                         % obj.pid_SpeedController.desiredSpeed = baseSpeed;
                         % if ~isnan(accelOverride)
                         %     desired_acceleration = accelOverride;

--- a/tests/ACCControllerTest.m
+++ b/tests/ACCControllerTest.m
@@ -1,0 +1,36 @@
+function tests = ACCControllerTest
+    tests = functiontests(localfunctions);
+end
+
+function setup(testCase)
+    testCase.TestData.ctrl = acc_Controller(0.75, 2.0, 12.0, 3.0);
+end
+
+function testStartDecel(testCase)
+    ctrl = testCase.TestData.ctrl;
+    % Distance corresponds to less than 5.5 s lookahead at 20 m/s
+    curSpeed = 20; pidAccel = 1; dist = 40; radius = 50; dt = 1;
+    [accelOut, rot] = ctrl.adjust(curSpeed, pidAccel, dist, radius, dt);
+    verifyEqual(testCase, accelOut, -2, 'AbsTol', 1e-10);
+    verifyGreaterThan(testCase, rot, 0);
+end
+
+function testNoDecelWhenFar(testCase)
+    ctrl = testCase.TestData.ctrl;
+    % Distance beyond 5.5 s lookahead should not trigger decel
+    curSpeed = 20; pidAccel = 1; dist = 120; radius = 50; dt = 1;
+    [accelOut, rot] = ctrl.adjust(curSpeed, pidAccel, dist, radius, dt);
+    verifyEqual(testCase, accelOut, pidAccel, 'AbsTol', 1e-10);
+    verifyGreaterThan(testCase, rot, 0);
+end
+
+function testMaintainSpeedInCurve(testCase)
+    ctrl = testCase.TestData.ctrl;
+    % Trigger decel first
+    curSpeed = 20; pidAccel = 1; dist = 40; radius = 50; dt = 1;
+    ctrl.adjust(curSpeed, pidAccel, dist, radius, dt);
+    % Once speed reaches target maintain 75%
+    curSpeed = 15; pidAccel = 2; dist = 0; radius = 20;
+    [accelOut, ~] = ctrl.adjust(curSpeed, pidAccel, dist, radius, dt);
+    verifyEqual(testCase, accelOut, 0, 'AbsTol', 1e-10);
+end

--- a/tests/VehicleLocalizerTest.m
+++ b/tests/VehicleLocalizerTest.m
@@ -1,0 +1,18 @@
+function tests = VehicleLocalizerTest
+    tests = functiontests(localfunctions);
+end
+
+function testLocalization(testCase)
+    wps = [0 0; 1 0; 2 0; 3 0];
+    loc = VehicleLocalizer(wps, 1.0);
+    idx = loc.localize([2.2 0]);
+    verifyEqual(testCase, idx, 3);
+end
+
+function testDistanceToCurve(testCase)
+    wps = [0 0; 1 0; 2 0; 3 0];
+    loc = VehicleLocalizer(wps, 1.0);
+    upcoming = [Inf Inf 10];
+    dist = loc.distanceToNextCurve(1, upcoming);
+    verifyEqual(testCase, dist, 2, 'AbsTol', 1e-10);
+end

--- a/tests/VehicleModelACCIntegrationTest.m
+++ b/tests/VehicleModelACCIntegrationTest.m
@@ -1,0 +1,13 @@
+function tests = VehicleModelACCIntegrationTest
+    tests = functiontests(localfunctions);
+end
+
+function testACCIntegration(testCase)
+    vm = VehicleModel([], [], false, 'sim', []);
+    vm.initializeDefaultParameters();
+    vm.initializeSim();
+    verifyTrue(testCase, isprop(vm, 'accController'));
+    verifyNotEmpty(testCase, vm.accController);
+    verifyTrue(testCase, isprop(vm, 'localizer'));
+    verifyNotEmpty(testCase, vm.localizer);
+end


### PR DESCRIPTION
## Summary
- refine `acc_Controller` to decelerate based on lookahead time from `VehicleLocalizer`
- use 5.5 s time horizon when instantiating the ACC controller
- adjust unit tests for updated deceleration rule

## Testing
- `matlab -batch "runtests('tests/ACCControllerTest.m'); runtests('tests/VehicleModelACCIntegrationTest.m'); runtests('tests/VehicleLocalizerTest.m');"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6844b740d9d48327af2cb055def2bea5