### PR TITLE
Improve trailer stability control

### DIFF
--- a/Source/Control/purePursuit_PathFollower.m
+++ b/Source/Control/purePursuit_PathFollower.m
@@ -94,6 +94,8 @@ classdef purePursuit_PathFollower
         % Low-Pass Filter Properties
         lowPassAlpha             % Low-pass filter coefficient (e.g., 0.1 for strong smoothing)
         prevLowPassOutput        % Previous output of the low-pass filter
+        % Maximum allowable lateral acceleration (m/s^2)
+        maxLateralAccel
     end
 
     methods
@@ -101,7 +103,7 @@ classdef purePursuit_PathFollower
         function obj = purePursuit_PathFollower(waypoints, wheelbase, lookaheadDistance, maxSteeringAngle, ...
                                      alpha, predictionTime, numPredictions, bufferHorizon, ...
                                      timeStep, R, offsetX, offsetY, historyBufferSize, ...
-                                     transmission, curvatureShiftThreshold, gaussianBufferSize, gaussianSigma)
+                                     transmission, curvatureShiftThreshold, gaussianBufferSize, gaussianSigma, maxLateralAccel)
             % Initialize purePursuit_PathFollower with required parameters.
             %
             % Parameters:
@@ -176,6 +178,9 @@ classdef purePursuit_PathFollower
             end
             if nargin < 17 || isempty(gaussianSigma)
                 gaussianSigma = 1; % Default sigma for Gaussian weights
+            end
+            if nargin < 18 || isempty(maxLateralAccel)
+                maxLateralAccel = 0.3 * 9.81; % 0.3g default lateral limit
             end
 
             if iscell(waypoints)
@@ -258,6 +263,9 @@ classdef purePursuit_PathFollower
             obj.curvatureShiftThreshold = curvatureShiftThreshold;
             obj.shiftedDownForCurrentCurve = false;
             % *** End of New Properties ***
+
+            % Set lateral acceleration limit
+            obj.maxLateralAccel = maxLateralAccel;
         end
 
         %% Update Vehicle State
@@ -367,6 +375,16 @@ classdef purePursuit_PathFollower
 
             % Use the low-pass filtered output as the final steering angle
             steeringAngle = filteredAngle;
+
+            % --- Limit lateral acceleration of trailer ---
+            if obj.speed > 0 && abs(steeringAngle) > 0
+                steerRad = deg2rad(steeringAngle);
+                latAccel = (obj.speed^2) * tan(steerRad) / obj.wheelbase;
+                if abs(latAccel) > obj.maxLateralAccel
+                    maxSteerRad = atan(obj.maxLateralAccel * obj.wheelbase / (obj.speed^2));
+                    steeringAngle = sign(steeringAngle) * rad2deg(maxSteerRad);
+                end
+            end
 
             % *** Gear Shifting Logic Based on Curvature ***
             % Analyze upcoming curvatures to determine if a gear shift is needed

--- a/Source/Physics/StabilityChecker.m
+++ b/Source/Physics/StabilityChecker.m
@@ -118,6 +118,7 @@ classdef StabilityChecker
 
         % Use a minimal or minimal-larger threshold if you want to filter out small angles
         minYawAmplitude = 0.005   % optional: ignore tiny differences if < 0.005 rad
+        yawAmplitudeThreshold = 0.02
     end
     
     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -287,8 +288,10 @@ classdef StabilityChecker
                 wiggleMeasure = 0;
             end
 
-            % 6) Compare wiggleMeasure to threshold
-            rawIsExceed = (wiggleMeasure > obj.wigglingThreshold);
+            % 6) Compare wiggleMeasure and amplitude to thresholds
+            amplitude = max(data) - min(data);
+            rawIsExceed = (wiggleMeasure > obj.wigglingThreshold) && ...
+                          (amplitude > obj.yawAmplitudeThreshold);
 
             % 7) Convert to score update
             if rawIsExceed


### PR DESCRIPTION
## Summary
- add maximum lateral acceleration limit in path follower to keep trailers stable
- expose new `maxLateralAccel` parameter in `purePursuit_PathFollower`
- refine wiggling detection with yaw amplitude threshold

## Testing
- `No MATLAB available`

------
https://chatgpt.com/codex/tasks/task_b_6845a3dce3bc8327872c9a676647c611