### PR TITLE
Fix yaw force separation

### DIFF
--- a/Scripts/Wrappers/ForceCalculator_computeTireForces_wrapper.m
+++ b/Scripts/Wrappers/ForceCalculator_computeTireForces_wrapper.m
@@ -31,5 +31,6 @@ function [F_y_total, M_z] = ForceCalculator_computeTireForces_wrapper(loads, con
             dt, trailerMass, trailerWheelbase, numTrailerTires, trailerBoxMasses, ...
             tireModelFlag, highFidelityModel, windVector, brakeSystem, varargin{:});
     end
-    [F_y_total, M_z] = fc.computeTireForces(loads, contactAreas, u, v, r);
+    idx = 1:numel(loads);
+    [F_y_total, M_z] = fc.computeTireForces(loads, contactAreas, u, v, r, idx);
 end


### PR DESCRIPTION
## Summary
- separate tractor and trailer tire forces when computing yaw
- support indexing for ForceCalculator.computeTireForces

## Testing
- `octave --eval "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6847c64bec488327a91d2aa93cab3390