### PR TITLE
Add GPU-enabled 3D animation

### DIFF
--- a/Source/Graphics/Boxel.m
+++ b/Source/Graphics/Boxel.m
@@ -1,0 +1,93 @@
+%{
+@file Boxel.m
+@brief Represents a simple 3D box element used to build graphics objects.
+%}
+
+classdef Boxel
+    properties
+        Position % [x y z] position of the box center
+        Size     % [length width height]
+        Color    % [r g b] color values between 0 and 1
+        UseGPU = false % Flag to compute vertices on the GPU
+    end
+    methods
+        function obj = Boxel(position, sz, color)
+            if nargin < 1
+                position = [0 0 0];
+            end
+            if nargin < 2
+                sz = [1 1 1];
+            end
+            if nargin < 3
+                color = [0.5 0.5 0.5];
+            end
+            obj.Position = position;
+            obj.Size = sz;
+            obj.Color = color;
+        end
+
+        function h = draw(obj, ax)
+            % draw Renders the boxel as a patch object in the provided axes.
+            %
+            %   h = draw(obj, ax) draws the boxel using the axes handle ax and
+            %   returns the patch handle h.
+            if nargin < 2 || isempty(ax)
+                ax = gca;
+            end
+
+            verts = obj.vertices();
+
+            if obj.UseGPU && gpuDeviceCount > 0
+                verts = gpuArray(verts); %#ok<GPUARRAY>
+                verts = gather(verts);
+            end
+
+            h = patch(ax, 'Vertices', verts, ...
+                'Faces', obj.faces(), ...
+                'FaceColor', obj.Color, 'EdgeColor', 'none');
+        end
+
+        function verts = vertices(obj)
+            % vertices Returns an 8x3 matrix of cuboid vertices in world coordinates.
+            [X, Y, Z] = obj.cuboidData();
+            verts = [X(:) Y(:) Z(:)];
+        end
+
+        function verts = localVertices(obj)
+            % localVertices Returns vertices relative to the object origin.
+            c = obj.Position - obj.Size/2;
+            X = [0 1 1 0 0 1 1 0]*obj.Size(1) + c(1);
+            Y = [0 0 1 1 0 0 1 1]*obj.Size(2) + c(2);
+            Z = [0 0 0 0 1 1 1 1]*obj.Size(3) + c(3);
+            if obj.UseGPU && gpuDeviceCount > 0
+                X = gpuArray(X); Y = gpuArray(Y); Z = gpuArray(Z); %#ok<GPUARRAY>
+                X = gather(X); Y = gather(Y); Z = gather(Z);
+            end
+            verts = [X(:) Y(:) Z(:)];
+        end
+
+        function F = faces(obj)
+            % faces Returns the face indices for the cuboid.
+            F = obj.cuboidFaces();
+        end
+    end
+
+    methods (Access = private)
+        function [X, Y, Z] = cuboidData(obj)
+            % cuboidData Generates vertices for the cuboid.
+            c = obj.Position - obj.Size/2;
+            X = [0 1 1 0 0 1 1 0]*obj.Size(1) + c(1);
+            Y = [0 0 1 1 0 0 1 1]*obj.Size(2) + c(2);
+            Z = [0 0 0 0 1 1 1 1]*obj.Size(3) + c(3);
+            if obj.UseGPU && gpuDeviceCount > 0
+                X = gpuArray(X); Y = gpuArray(Y); Z = gpuArray(Z); %#ok<GPUARRAY>
+                X = gather(X); Y = gather(Y); Z = gather(Z);
+            end
+        end
+
+        function F = cuboidFaces(~)
+            % cuboidFaces Returns face indices for a cuboid.
+            F = [1 2 3 4; 5 6 7 8; 1 2 6 5; 2 3 7 6; 3 4 8 7; 4 1 5 8];
+        end
+    end
+end

--- a/Source/Graphics/Building3D.m
+++ b/Source/Graphics/Building3D.m
@@ -1,0 +1,21 @@
+%{
+@file Building3D.m
+@brief Simple example object representing a building constructed from Boxels.
+%}
+
+classdef Building3D < Object3D
+    methods
+        function obj = Building3D(position, width, depth, height, color)
+            if nargin < 5
+                color = [0.8 0.8 0.8];
+            end
+            obj@Object3D();
+            nFloors = max(1, round(height));
+            for f = 1:nFloors
+                b = Boxel([0 0 (f-0.5)], [width depth 1], color);
+                obj.addBoxel(b);
+            end
+            obj.Position = position;
+        end
+    end
+end

--- a/Source/Graphics/GraphicsWindow.m
+++ b/Source/Graphics/GraphicsWindow.m
@@ -1,0 +1,77 @@
+%{
+@file GraphicsWindow.m
+@brief Provides a window for rendering a World3D scene and running animations.
+%}
+
+classdef GraphicsWindow < handle
+    properties
+        World % World3D instance to render
+        Figure
+        Axes
+        UseGPU = false
+    end
+
+    methods
+        function obj = GraphicsWindow(world, useGPU)
+            if nargin < 1 || isempty(world)
+                obj.World = World3D();
+            else
+                obj.World = world;
+            end
+            if nargin < 2
+                useGPU = false;
+            end
+            obj.UseGPU = useGPU;
+            obj.World.UseGPU = useGPU;
+            obj.Figure = figure('Name','VDSS 3D View');
+            obj.Axes = axes('Parent', obj.Figure);
+            axis(obj.Axes,'equal');
+            view(obj.Axes,3);
+            grid(obj.Axes,'on');
+            xlabel(obj.Axes,'X'); ylabel(obj.Axes,'Y'); zlabel(obj.Axes,'Z');
+            rotate3d(obj.Figure,'on');
+            set(obj.Figure,'WindowScrollWheelFcn',@(src,evt)obj.scrollZoom(evt));
+        end
+
+        function render(obj)
+            cla(obj.Axes);
+            if ~isempty(obj.World)
+                obj.World.UseGPU = obj.UseGPU;
+                obj.World.draw(obj.Axes);
+            end
+            drawnow;
+        end
+
+        function animate(obj, updateFcn, steps, dt)
+            if nargin < 4 || isempty(dt)
+                dt = 0.05;
+            end
+            if nargin < 3 || isempty(steps)
+                steps = 1;
+            end
+            for k = 1:steps
+                if nargin >= 2 && ~isempty(updateFcn)
+                    updateFcn(k);
+                end
+                obj.render();
+                pause(dt);
+            end
+        end
+
+        function zoomIn(obj)
+            camzoom(obj.Axes, 1.2);
+        end
+
+        function zoomOut(obj)
+            camzoom(obj.Axes, 0.8);
+        end
+
+        function scrollZoom(obj, evt)
+            if evt.VerticalScrollCount > 0
+                camzoom(obj.Axes, 1.1);
+            else
+                camzoom(obj.Axes, 0.9);
+            end
+        end
+    end
+end

--- a/Source/Graphics/Object3D.m
+++ b/Source/Graphics/Object3D.m
@@ -1,0 +1,114 @@
+%{
+@file Object3D.m
+@brief Combines multiple Boxel objects into a single drawable graphic.
+%}
+
+classdef Object3D
+    properties
+        Boxels = Boxel.empty
+        Position = [0 0 0]
+        Orientation = eye(3)
+        UseGPU = false
+    end
+
+    methods
+        function obj = Object3D(boxels, useGPU)
+            if nargin < 1
+                boxels = Boxel.empty;
+            end
+            if nargin < 2
+                useGPU = false;
+            end
+            obj.Boxels = boxels;
+            obj.UseGPU = useGPU;
+        end
+
+        function addBoxel(obj, boxel)
+            if obj.UseGPU
+                boxel.UseGPU = true;
+            end
+            obj.Boxels(end+1) = boxel;
+        end
+
+        function setOrientation(obj, yaw, pitch, roll)
+            % setOrientation Sets the object orientation from yaw, pitch, roll (rad).
+            if nargin == 2 && ismatrix(yaw)
+                obj.Orientation = yaw;
+                return;
+            end
+            if nargin < 4, roll = 0; end
+            if nargin < 3, pitch = 0; end
+            if nargin < 2, yaw = 0; end
+            Rz = [cos(yaw) -sin(yaw) 0; sin(yaw) cos(yaw) 0; 0 0 1];
+            Ry = [cos(pitch) 0 sin(pitch); 0 1 0; -sin(pitch) 0 cos(pitch)];
+            Rx = [1 0 0; 0 cos(roll) -sin(roll); 0 sin(roll) cos(roll)];
+            obj.Orientation = Rz*Ry*Rx;
+        end
+
+        function h = draw(obj, ax)
+            % draw Renders the composed object by drawing each boxel.
+            if nargin < 2 || isempty(ax)
+                ax = gca;
+            end
+            holdState = ishold(ax);
+            hold(ax, 'on');
+            for i = 1:numel(obj.Boxels)
+                b = obj.Boxels(i);
+                verts = b.localVertices();
+                if obj.UseGPU && gpuDeviceCount > 0
+                    verts = gpuArray(verts); %#ok<GPUARRAY>
+                    R = gpuArray(obj.Orientation); %#ok<GPUARRAY>
+                    verts = (R * verts.').';
+                    verts = verts + gpuArray(obj.Position);
+                    verts = gather(verts);
+                else
+                    verts = (obj.Orientation * verts.').';
+                    verts = verts + obj.Position;
+                end
+                patch(ax, 'Vertices', verts, 'Faces', b.faces(), ...
+                    'FaceColor', b.Color, 'EdgeColor', 'none');
+            end
+            if ~holdState
+                hold(ax, 'off');
+            end
+            h = []; % return handle array in future
+        end
+
+        function h = smoothSurface(obj, ax, alpha)
+            % smoothSurface Draws a smoothed version of the composed object.
+            %   This function computes an alpha shape of all vertices
+            %   from the contained boxels to produce a smoother looking
+            %   surface. A patch handle is returned.
+
+            if nargin < 2 || isempty(ax)
+                ax = gca;
+            end
+            if nargin < 3
+                alpha = 1.5;
+            end
+
+            verts = obj.collectMesh();
+            shp = alphaShape(verts, alpha);
+            [facesS, vertsS] = boundaryFacets(shp);
+
+            h = patch(ax, 'Vertices', vertsS, 'Faces', facesS, ...
+                'FaceColor', 'interp', 'EdgeColor', 'none');
+        end
+    end
+
+    methods (Access = private)
+        function verts = collectMesh(obj)
+            % collectMesh Collects transformed vertices from all boxels
+            verts = [];
+            idx = 0;
+            for i = 1:numel(obj.Boxels)
+                b = obj.Boxels(i);
+                v = b.localVertices();
+                v = (obj.Orientation * v.').';
+                v = v + obj.Position;
+                verts = [verts; v]; %#ok<AGROW>
+                idx = idx + size(v,1);
+            end
+        end
+    end
+end

--- a/Source/Graphics/Road3D.m
+++ b/Source/Graphics/Road3D.m
@@ -1,0 +1,18 @@
+%{
+@file Road3D.m
+@brief Simple road segment constructed from a single Boxel.
+%}
+
+classdef Road3D < Object3D
+    methods
+        function obj = Road3D(startPos, len, width, color)
+            if nargin < 4
+                color = [0.2 0.2 0.2];
+            end
+            obj@Object3D();
+            b = Boxel([len/2 0 0], [len width 0.1], color);
+            obj.addBoxel(b);
+            obj.Position = startPos;
+        end
+    end
+end

--- a/Source/Graphics/Sim3DAnimator.m
+++ b/Source/Graphics/Sim3DAnimator.m
@@ -1,0 +1,55 @@
+%{
+@file Sim3DAnimator.m
+@brief Animates simulation results using the 3D graphics framework.
+%}
+
+classdef Sim3DAnimator < handle
+    properties
+        DataManager
+        GraphicsWindow
+        Vehicle1
+        Vehicle2
+        Steps
+    end
+
+    methods
+        function obj = Sim3DAnimator(dataManager, graphicsWindow)
+            if nargin < 2 || isempty(graphicsWindow)
+                graphicsWindow = GraphicsWindow();
+            end
+            obj.DataManager = dataManager;
+            obj.GraphicsWindow = graphicsWindow;
+            obj.Steps = numel(dataManager.globalVehicle1Data.X);
+
+            % Simple vehicle representations using vehicle parts
+            obj.Vehicle1 = Tractor3D();
+            obj.Vehicle2 = Tractor3D();
+            obj.GraphicsWindow.World.addObject(obj.Vehicle1);
+            obj.GraphicsWindow.World.addObject(obj.Vehicle2);
+        end
+
+        function run(obj, dt)
+            if nargin < 2
+                dt = obj.DataManager.dt;
+            end
+            for k = 1:obj.Steps
+                obj.updateVehicles(k);
+                obj.GraphicsWindow.render();
+                pause(dt);
+            end
+        end
+
+        function updateVehicles(obj, k)
+            if k > obj.Steps
+                return;
+            end
+            obj.Vehicle1.Position = [obj.DataManager.globalVehicle1Data.X(k), ...
+                                     obj.DataManager.globalVehicle1Data.Y(k), 0];
+            obj.Vehicle1.setOrientation(obj.DataManager.globalVehicle1Data.Theta(k));
+
+            obj.Vehicle2.Position = [obj.DataManager.globalVehicle2Data.X(k), ...
+                                     obj.DataManager.globalVehicle2Data.Y(k), 0];
+            obj.Vehicle2.setOrientation(obj.DataManager.globalVehicle2Data.Theta(k));
+        end
+    end
+end

--- a/Source/Graphics/Tire3D.m
+++ b/Source/Graphics/Tire3D.m
@@ -1,0 +1,31 @@
+%{
+@file Tire3D.m
+@brief Vehicle tire composed of multiple Boxels forming a ring.
+%}
+
+classdef Tire3D < VehiclePart3D
+    methods
+        function obj = Tire3D(radius, width, color, nSegments)
+            if nargin < 4
+                nSegments = 12;
+            end
+            if nargin < 3
+                color = [0 0 0];
+            end
+            if nargin < 2
+                width = 0.3;
+            end
+            if nargin < 1
+                radius = 0.5;
+            end
+            obj@VehiclePart3D('Tire');
+            for k = 1:nSegments
+                ang = 2*pi*(k-1)/nSegments;
+                pos = [radius*cos(ang) radius*sin(ang) 0];
+                segSize = [width radius*2*sin(pi/nSegments) radius*2*sin(pi/nSegments)];
+                b = Boxel(pos + [0 0 segSize(3)/2], segSize, color);
+                obj.addBoxel(b);
+            end
+        end
+    end
+end

--- a/Source/Graphics/Tractor3D.m
+++ b/Source/Graphics/Tractor3D.m
@@ -1,0 +1,26 @@
+%{
+@file Tractor3D.m
+@brief Simple tractor body built from Boxels.
+%}
+
+classdef Tractor3D < VehiclePart3D
+    methods
+        function obj = Tractor3D(length, width, height, color)
+            if nargin < 4
+                color = [1 0 0];
+            end
+            if nargin < 3
+                height = 1.5;
+            end
+            if nargin < 2
+                width = 1.0;
+            end
+            if nargin < 1
+                length = 3.0;
+            end
+            obj@VehiclePart3D('Tractor');
+            b = Boxel([length/2 0 height/2], [length width height], color);
+            obj.addBoxel(b);
+        end
+    end
+end

--- a/Source/Graphics/Trailer3D.m
+++ b/Source/Graphics/Trailer3D.m
@@ -1,0 +1,26 @@
+%{
+@file Trailer3D.m
+@brief Simple trailer body built from Boxels.
+%}
+
+classdef Trailer3D < VehiclePart3D
+    methods
+        function obj = Trailer3D(length, width, height, color)
+            if nargin < 4
+                color = [0 0 1];
+            end
+            if nargin < 3
+                height = 2.5;
+            end
+            if nargin < 2
+                width = 1.0;
+            end
+            if nargin < 1
+                length = 6.0;
+            end
+            obj@VehiclePart3D('Trailer');
+            b = Boxel([length/2 0 height/2], [length width height], color);
+            obj.addBoxel(b);
+        end
+    end
+end

--- a/Source/Graphics/VehiclePart3D.m
+++ b/Source/Graphics/VehiclePart3D.m
@@ -1,0 +1,25 @@
+%{
+@file VehiclePart3D.m
+@brief Base class for vehicle parts composed of Boxel objects.
+%}
+
+classdef VehiclePart3D < Object3D
+    properties
+        Name
+    end
+    methods
+        function obj = VehiclePart3D(name, boxels, useGPU)
+            if nargin < 1
+                name = '';
+            end
+            if nargin < 2
+                boxels = Boxel.empty;
+            end
+            if nargin < 3
+                useGPU = false;
+            end
+            obj@Object3D(boxels, useGPU);
+            obj.Name = name;
+        end
+    end
+end

--- a/Source/Graphics/World3D.m
+++ b/Source/Graphics/World3D.m
@@ -1,0 +1,47 @@
+%{
+@file World3D.m
+@brief Manages and draws a collection of Object3D instances to form a scene.
+%}
+
+classdef World3D < handle
+    properties
+        Objects = Object3D.empty
+        CameraPosition = [10 10 10]
+        CameraTarget = [0 0 0]
+        UseGPU = false
+    end
+
+    methods
+        function addObject(obj, object3d)
+            if obj.UseGPU
+                object3d.UseGPU = true;
+            end
+            obj.Objects(end+1) = object3d;
+        end
+
+        function clear(obj)
+            obj.Objects = Object3D.empty;
+        end
+
+        function draw(obj, ax)
+            % draw Renders all objects in the world.
+            if nargin < 2 || isempty(ax)
+                ax = gca;
+            end
+            view(ax, 3);
+            grid(ax, 'on');
+            holdState = ishold(ax);
+            hold(ax, 'on');
+            for i = 1:numel(obj.Objects)
+                obj.Objects(i).draw(ax);
+            end
+            if ~holdState
+                hold(ax, 'off');
+            end
+            xlabel(ax,'X'); ylabel(ax,'Y'); zlabel(ax,'Z');
+            camproj(ax,'perspective');
+            campos(ax, obj.CameraPosition);
+            camtarget(ax, obj.CameraTarget);
+        end
+    end
+end

--- a/VDSS.m
+++ b/VDSS.m
@@ -488,6 +488,13 @@ function VDSS
     % */
     function startSimulation()
         simulationManager.runSimulations();
+        try
+            gw = GraphicsWindow(World3D(), true);
+            animator = Sim3DAnimator(dataManager, gw);
+            animator.run();
+        catch ME
+            disp(['3D Animation failed: ' ME.message]);
+        end
     end
     
     %/**


### PR DESCRIPTION
## Summary
- accelerate Boxel and Object3D calculations on the GPU
- allow World3D and GraphicsWindow to pass GPU settings
- add zoom/rotation interaction support
- integrate 3D animator with the main VDSS script
- implement `Sim3DAnimator` for playing back simulation results
- introduce classes for vehicle parts and a surface smoothing method

## Testing
- `matlab -batch "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6848184d563c832794af9d43448734f9