### PR TITLE
Fix mass scaling for multi-box trailers

### DIFF
--- a/Source/GUI/DataManager.m
+++ b/Source/GUI/DataManager.m
@@ -238,6 +238,11 @@ classdef DataManager < handle
             if isfield(simParams,'trailerBoxWeightDistributions') && ~isempty(simParams.trailerBoxWeightDistributions)
                 boxMasses = cellfun(@(ld) sum(ld(:,4))/9.81, simParams.trailerBoxWeightDistributions);
                 massVal = sum(boxMasses);
+            elseif isfield(simParams,'trailerNumBoxes') && simParams.trailerNumBoxes > 1
+                % Assume trailerMass corresponds to a single box when
+                % distributions are absent, scaling by the number of boxes to
+                % maintain realistic mass in the logs and plots.
+                massVal = simParams.trailerMass * simParams.trailerNumBoxes;
             end
 
             trailerParams = struct(...

--- a/Source/Simulation/SimManager.m
+++ b/Source/Simulation/SimManager.m
@@ -1158,6 +1158,12 @@ classdef SimManager < handle
             if isfield(simParams,'trailerBoxWeightDistributions') && ~isempty(simParams.trailerBoxWeightDistributions)
                 boxMasses = cellfun(@(ld) sum(ld(:,4))/9.81, simParams.trailerBoxWeightDistributions);
                 massVal = sum(boxMasses);
+            elseif isfield(simParams,'trailerNumBoxes') && simParams.trailerNumBoxes > 1
+                % When multiple trailer boxes are present but individual weight
+                % distributions are not provided, assume the configured trailer
+                % mass represents a single box. Scale it by the number of boxes
+                % so dynamics correctly account for the additional mass.
+                massVal = simParams.trailerMass * simParams.trailerNumBoxes;
             end
             fprintf('Total vehicle mass updated: %.2f kg\n', simParams.tractorMass + massVal);
 

--- a/Source/Vehicle Model/VehicleModel.m
+++ b/Source/Vehicle Model/VehicleModel.m
@@ -693,6 +693,12 @@ classdef VehicleModel < handle
                 end
                 simParams.trailerMass = totalMass;
                 fprintf('Total vehicle mass updated: %.2f kg\n', simParams.tractorMass + totalMass);
+            elseif simParams.trailerNumBoxes > 1
+                % No individual weight distributions provided, so scale the
+                % configured trailer mass by the number of boxes. This prevents
+                % unrealistically low mass when multiple boxes are added.
+                simParams.trailerMass = simParams.trailerMass * simParams.trailerNumBoxes;
+                fprintf('Total vehicle mass updated: %.2f kg\n', simParams.tractorMass + simParams.trailerMass);
             end
             % --- Spinner Configuration Parameters ---
             nSpinners = max(simParams.trailerNumBoxes - 1, 0);


### PR DESCRIPTION
## Summary
- ensure mass scales with number of trailer boxes when weight distributions aren't provided
- adjust DataManager and SimManager to account for multiple boxes
- update setSimulationParameters to scale trailerMass when boxes increase

## Testing
- `npm` *(fails: unknown env config)*

------
https://chatgpt.com/codex/tasks/task_b_68497f97a8c8832792a1aafb9169559e