### PR TITLE
Fix mass scaling for multi-box trailers

### DIFF
--- a/Source/GUI/DataManager.m
+++ b/Source/GUI/DataManager.m
@@ -238,6 +238,11 @@ classdef DataManager < handle
             if isfield(simParams,'trailerBoxWeightDistributions') && ~isempty(simParams.trailerBoxWeightDistributions)
                 boxMasses = cellfun(@(ld) sum(ld(:,4))/9.81, simParams.trailerBoxWeightDistributions);
                 massVal = sum(boxMasses);
+            elseif isfield(simParams,'trailerNumBoxes') && simParams.trailerNumBoxes > 1
+                % Assume trailerMass corresponds to a single box when
+                % distributions are absent, scaling by the number of boxes to
+                % maintain realistic mass in the logs and plots.
+                massVal = simParams.trailerMass * simParams.trailerNumBoxes;
             end
 
             trailerParams = struct(...

--- a/Source/Physics/ForceCalculator.m
+++ b/Source/Physics/ForceCalculator.m
@@ -571,7 +571,9 @@ classdef ForceCalculator
             M_roll= 0;
 
             % Gravity in vehicle frame
-            F_g_vehicle = [obj.vehicleMass*obj.gravity*sin(obj.slopeAngle);
+            % Gravitational force components due to road slope
+            % Positive slopeAngle should resist forward motion (uphill)
+            F_g_vehicle = [-obj.vehicleMass*obj.gravity*sin(obj.slopeAngle);
                            0;
                           -obj.vehicleMass*obj.gravity*cos(obj.slopeAngle)];
             totalForce_vehicle = totalForce_vehicle + F_g_vehicle;
@@ -644,7 +646,8 @@ classdef ForceCalculator
                     F_lat_v = [0;F_y_total;0] + F_side_v;
 
                     % Rolling resistance
-                    F_rr = sum(obj.rollingResistanceCoefficients.*loads);
+                    % Rolling resistance scales with normal force and road slope
+                    F_rr = cos(obj.slopeAngle) * sum(obj.rollingResistanceCoefficients.*loads);
                     F_rr_v = -F_rr*[1;0;0];
 
                     % Suspension
@@ -741,7 +744,7 @@ classdef ForceCalculator
                             else
                                 totalTrMass = obj.trailerMass;
                             end
-                            F_rr_tr = obj.rollingResistanceCoefficients(1)*(totalTrMass*obj.gravity);
+                            F_rr_tr = obj.rollingResistanceCoefficients(1)*(totalTrMass*obj.gravity*cos(obj.slopeAngle));
                             F_rr_tr_local = -F_rr_tr*[1;0;0];
 
                             F_total_tr_local = [F_longitudinal_tr; F_lateral_trailer;0] + ...
@@ -835,7 +838,7 @@ classdef ForceCalculator
                     obj.calculatedForces.M_z       = M_z;
 
                     F_lat_v= [0;F_y_total;0] + F_side_v;
-                    F_rr = sum(obj.rollingResistanceCoefficients.*loads);
+                    F_rr = cos(obj.slopeAngle) * sum(obj.rollingResistanceCoefficients.*loads);
                     F_rr_v= -F_rr*[1;0;0];
                     [F_susp_, ~]= obj.suspensionModel.calculateForcesAndMoments(vehicleState);
                     F_susp_v= [0;0;F_susp_];
@@ -919,7 +922,7 @@ classdef ForceCalculator
                             else
                                 totalTrMass = obj.trailerMass;
                             end
-                            F_rr_tr= obj.rollingResistanceCoefficients(1)*(totalTrMass*obj.gravity);
+                            F_rr_tr= obj.rollingResistanceCoefficients(1)*(totalTrMass*obj.gravity*cos(obj.slopeAngle));
                             F_rr_tr_local= -F_rr_tr*[1;0;0];
                             F_total_tr_local= [F_longitudinal_tr;F_lateral_trailer;0] + ...
                                               F_side_tr_local+ F_rr_tr_local;

--- a/Source/Simulation/SimManager.m
+++ b/Source/Simulation/SimManager.m
@@ -1158,6 +1158,12 @@ classdef SimManager < handle
             if isfield(simParams,'trailerBoxWeightDistributions') && ~isempty(simParams.trailerBoxWeightDistributions)
                 boxMasses = cellfun(@(ld) sum(ld(:,4))/9.81, simParams.trailerBoxWeightDistributions);
                 massVal = sum(boxMasses);
+            elseif isfield(simParams,'trailerNumBoxes') && simParams.trailerNumBoxes > 1
+                % When multiple trailer boxes are present but individual weight
+                % distributions are not provided, assume the configured trailer
+                % mass represents a single box. Scale it by the number of boxes
+                % so dynamics correctly account for the additional mass.
+                massVal = simParams.trailerMass * simParams.trailerNumBoxes;
             end
             fprintf('Total vehicle mass updated: %.2f kg\n', simParams.tractorMass + massVal);
 

--- a/Source/Vehicle Model/VehicleModel.m
+++ b/Source/Vehicle Model/VehicleModel.m
@@ -693,6 +693,12 @@ classdef VehicleModel < handle
                 end
                 simParams.trailerMass = totalMass;
                 fprintf('Total vehicle mass updated: %.2f kg\n', simParams.tractorMass + totalMass);
+            elseif simParams.trailerNumBoxes > 1
+                % No individual weight distributions provided, so scale the
+                % configured trailer mass by the number of boxes. This prevents
+                % unrealistically low mass when multiple boxes are added.
+                simParams.trailerMass = simParams.trailerMass * simParams.trailerNumBoxes;
+                fprintf('Total vehicle mass updated: %.2f kg\n', simParams.tractorMass + simParams.trailerMass);
             end
             % --- Spinner Configuration Parameters ---
             nSpinners = max(simParams.trailerNumBoxes - 1, 0);


### PR DESCRIPTION
## Summary
- ensure mass scales with number of trailer boxes when weight distributions aren't provided
- adjust DataManager and SimManager to account for multiple boxes
- update setSimulationParameters to scale trailerMass when boxes increase
- correct gravity and rolling resistance calculations so heavier vehicles don't accelerate unrealistically

## Testing
- `npm` *(fails: unknown env config)*

------
https://chatgpt.com/codex/tasks/task_b_68497f97a8c8832792a1aafb9169559e