### PR TITLE
Fix trailer mass scaling

### DIFF
--- a/Source/GUI/DataManager.m
+++ b/Source/GUI/DataManager.m
@@ -233,11 +233,17 @@ classdef DataManager < handle
             numAxles = sum(boxNumAxles);
 
             % Compute trailer mass from weight distributions when available
-            massVal = simParams.trailerMass;
+            if isfield(simParams, 'baseTrailerMass')
+                massVal = simParams.baseTrailerMass;
+            else
+                massVal = simParams.trailerMass;
+            end
             boxMasses = [];
             if isfield(simParams,'trailerBoxWeightDistributions') && ~isempty(simParams.trailerBoxWeightDistributions)
                 boxMasses = cellfun(@(ld) sum(ld(:,4))/9.81, simParams.trailerBoxWeightDistributions);
                 massVal = sum(boxMasses);
+            elseif isfield(simParams,'trailerNumBoxes') && simParams.trailerNumBoxes > 1
+                massVal = massVal * simParams.trailerNumBoxes;
             end
 
             trailerParams = struct(...

--- a/Source/Simulation/SimManager.m
+++ b/Source/Simulation/SimManager.m
@@ -1153,11 +1153,17 @@ classdef SimManager < handle
             middleAxleIndex   = ceil(numAxlesTractor / 2);
             middleAxlePosition = axlePositionsTractor(middleAxleIndex);
 
-            massVal = simParams.trailerMass;
+            if isfield(simParams, 'baseTrailerMass')
+                massVal = simParams.baseTrailerMass;
+            else
+                massVal = simParams.trailerMass;
+            end
             boxMasses = [];
             if isfield(simParams,'trailerBoxWeightDistributions') && ~isempty(simParams.trailerBoxWeightDistributions)
                 boxMasses = cellfun(@(ld) sum(ld(:,4))/9.81, simParams.trailerBoxWeightDistributions);
                 massVal = sum(boxMasses);
+            elseif isfield(simParams,'trailerNumBoxes') && simParams.trailerNumBoxes > 1
+                massVal = massVal * simParams.trailerNumBoxes;
             end
             fprintf('Total vehicle mass updated: %.2f kg\n', simParams.tractorMass + massVal);
 

--- a/tests/TrailerMassScalingTest.m
+++ b/tests/TrailerMassScalingTest.m
@@ -1,0 +1,38 @@
+%--------------------------------------------------------------------------
+% This file is part of VDSS - Vehicle Dynamics Safety Simulator.
+%
+% VDSS is free software: you can redistribute it and/or modify
+% it under the terms of the GNU General Public License as published by
+% the Free Software Foundation, either version 3 of the License, or
+% (at your option) any later version.
+%
+% VDSS is distributed in the hope that it will be useful,
+% but WITHOUT ANY WARRANTY; without even the implied warranty of
+% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+% GNU General Public License for more details.
+%
+% You should have received a copy of the GNU General Public License
+% along with this program. If not, see <https://www.gnu.org/licenses/>.
+%--------------------------------------------------------------------------
+function tests = TrailerMassScalingTest
+    tests = functiontests(localfunctions);
+end
+
+function testSetSimulationParametersIdempotent(testCase)
+    vm = VehicleModel([], [], false, 'sim', []);
+    vm.initializeDefaultParameters();
+
+    sp = vm.simParams;
+    sp.trailerNumBoxes = 2;
+    sp.baseTrailerMass = sp.trailerMass;
+    sp.trailerMassScaled = false;
+
+    vm.setSimulationParameters(sp);
+    firstMass = vm.simParams.trailerMass;
+
+    % Call again with the already-set parameters
+    vm.setSimulationParameters(vm.simParams);
+    secondMass = vm.simParams.trailerMass;
+
+    verifyEqual(testCase, firstMass, secondMass, 'AbsTol', 1e-10);
+end


### PR DESCRIPTION
## Summary
- avoid repeated scaling of trailer mass when no weight distributions are given
- keep original trailer mass in `baseTrailerMass`
- use `baseTrailerMass` when creating trailer parameters
- add regression test for mass scaling

## Testing
- `matlab -batch "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684988e8e8188327ad6dfb36da0639b7