### PR TITLE
Fix trailer mass scaling for multiple boxes

### DIFF
--- a/Source/Vehicle Model/VehicleModel.m
+++ b/Source/Vehicle Model/VehicleModel.m
@@ -712,8 +712,16 @@ classdef VehicleModel < handle
             elseif simParams.trailerNumBoxes > 1
                 % No individual weight distributions provided, so scale the
                 % configured trailer mass by the number of boxes only once.
-                if ~isfield(simParams, 'baseTrailerMass')
-                    simParams.baseTrailerMass = simParams.trailerMass;
+                % Use the previously stored trailer mass values if available.
+                if ~isfield(simParams, 'baseTrailerMass') || isempty(simParams.baseTrailerMass)
+                    if isfield(obj.simParams, 'baseTrailerMass')
+                        simParams.baseTrailerMass = obj.simParams.baseTrailerMass;
+                    else
+                        simParams.baseTrailerMass = obj.simParams.trailerMass;
+                    end
+                end
+                if ~isfield(simParams, 'trailerMass') || isempty(simParams.trailerMass)
+                    simParams.trailerMass = obj.simParams.trailerMass;
                 end
                 simParams.trailerMass = simParams.baseTrailerMass * simParams.trailerNumBoxes;
                 simParams.trailerMassScaled = true;


### PR DESCRIPTION
## Summary
- use stored trailer mass when scaling mass for multiple boxes

## Testing
- `matlab -batch "addpath('tests'); results = runtests('tests'); assertSuccess(results);"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68498b63d26c8327934c9e0bd73acd9c