### PR TITLE
Enable GPU threaded rendering

### DIFF
--- a/PythonGraphics/animation.py
+++ b/PythonGraphics/animation.py
@@ -1,0 +1,41 @@
+import csv
+import numpy as np
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
+from .world import World3D
+from .truck import Truck
+
+class SimulationAnimator:
+    """Animate simulation results using matplotlib."""
+
+    def __init__(self, csv_file):
+        self.csv_file = csv_file
+        self.world = World3D()
+        self.vehicle = Truck()
+        self.world.add(self.vehicle)
+
+    def load_data(self):
+        with open(self.csv_file, 'r') as f:
+            reader = csv.DictReader(f)
+            self.frames = [row for row in reader]
+
+    def animate(self):
+        self.load_data()
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection='3d')
+
+        for frame in self.frames:
+            ax.cla()
+            x = float(frame.get('x', 0))
+            y = float(frame.get('y', 0))
+            yaw = float(frame.get('yaw', 0))
+            self.vehicle.position = np.array([x, y, 0])
+            c = np.cos(yaw)
+            s = np.sin(yaw)
+            self.vehicle.orientation = np.array([[c,-s,0],[s,c,0],[0,0,1]])
+            self.vehicle.draw(ax)
+            ax.set_xlim(-10, 10)
+            ax.set_ylim(-10, 10)
+            ax.set_zlim(0, 5)
+            plt.pause(0.01)
+        plt.show()

--- a/PythonGraphics/boxel.py
+++ b/PythonGraphics/boxel.py
@@ -1,0 +1,35 @@
+import numpy as np
+from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+
+class Boxel:
+    """Represents a single cuboid primitive."""
+
+    def __init__(self, center, size, color='b'):
+        self.center = np.asarray(center, dtype=float)
+        self.size = np.asarray(size, dtype=float)
+        self.color = color
+
+    def vertices(self):
+        cx, cy, cz = self.center
+        sx, sy, sz = self.size / 2
+        # 8 vertices of the cuboid
+        return np.array([
+            [cx - sx, cy - sy, cz - sz],
+            [cx + sx, cy - sy, cz - sz],
+            [cx + sx, cy + sy, cz - sz],
+            [cx - sx, cy + sy, cz - sz],
+            [cx - sx, cy - sy, cz + sz],
+            [cx + sx, cy - sy, cz + sz],
+            [cx + sx, cy + sy, cz + sz],
+            [cx - sx, cy + sy, cz + sz],
+        ])
+
+    def faces(self):
+        v = self.vertices()
+        return [v[[0,1,2,3]], v[[4,5,6,7]], v[[0,1,5,4]],
+                v[[2,3,7,6]], v[[1,2,6,5]], v[[0,3,7,4]]]
+
+    def draw(self, ax):
+        faces = self.faces()
+        poly3d = Poly3DCollection(faces, facecolors=self.color, linewidths=0.5, edgecolors='k', alpha=0.7)
+        ax.add_collection3d(poly3d)

--- a/PythonGraphics/example.py
+++ b/PythonGraphics/example.py
@@ -1,0 +1,6 @@
+"""Example usage of the Python graphics module."""
+from .animation import SimulationAnimator
+
+if __name__ == '__main__':
+    anim = SimulationAnimator('Simulations/trajectory.csv')
+    anim.animate()

--- a/PythonGraphics/object3d.py
+++ b/PythonGraphics/object3d.py
@@ -1,0 +1,21 @@
+import numpy as np
+from .boxel import Boxel
+
+class Object3D:
+    """Composite 3D object made from Boxels."""
+
+    def __init__(self, boxels=None, position=(0,0,0)):
+        self.boxels = list(boxels) if boxels else []
+        self.position = np.asarray(position, dtype=float)
+        self.orientation = np.eye(3)
+
+    def add_boxel(self, boxel: Boxel):
+        self.boxels.append(boxel)
+
+    def transform_vertices(self, verts):
+        return (self.orientation @ verts.T).T + self.position
+
+    def draw(self, ax):
+        for boxel in self.boxels:
+            b = Boxel(self.transform_vertices(boxel.center), boxel.size, boxel.color)
+            b.draw(ax)

--- a/PythonGraphics/truck.py
+++ b/PythonGraphics/truck.py
@@ -1,0 +1,10 @@
+from .vehicle import Vehicle
+from .boxel import Boxel
+
+class Truck(Vehicle):
+    """Simple tractor + trailer."""
+
+    def __init__(self):
+        super().__init__(length=4.0, width=2.0, height=1.5, color='silver')
+        trailer = Boxel(center=(6.0, 0, 1.5/2), size=(8.0, 2.5, 1.5), color='gray')
+        self.add_boxel(trailer)

--- a/PythonGraphics/vehicle.py
+++ b/PythonGraphics/vehicle.py
@@ -1,0 +1,14 @@
+import numpy as np
+from .object3d import Object3D
+from .boxel import Boxel
+
+class Vehicle(Object3D):
+    """Base class for vehicles composed of boxels."""
+
+    def __init__(self, length, width, height, color='blue'):
+        super().__init__()
+        body = Boxel(center=(0, 0, height/2), size=(length, width, height), color=color)
+        self.add_boxel(body)
+        self.length = length
+        self.width = width
+        self.height = height

--- a/PythonGraphics/world.py
+++ b/PythonGraphics/world.py
@@ -1,0 +1,21 @@
+from mpl_toolkits.mplot3d import Axes3D
+import matplotlib.pyplot as plt
+
+class World3D:
+    """Container for rendering multiple Object3D instances."""
+
+    def __init__(self):
+        self.objects = []
+
+    def add(self, obj):
+        self.objects.append(obj)
+
+    def draw(self):
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection='3d')
+        ax.set_xlabel('X')
+        ax.set_ylabel('Y')
+        ax.set_zlabel('Z')
+        for obj in self.objects:
+            obj.draw(ax)
+        plt.show()

--- a/Source/Graphics/Boxel.m
+++ b/Source/Graphics/Boxel.m
@@ -1,0 +1,93 @@
+%{
+@file Boxel.m
+@brief Represents a simple 3D box element used to build graphics objects.
+%}
+
+classdef Boxel
+    properties
+        Position % [x y z] position of the box center
+        Size     % [length width height]
+        Color    % [r g b] color values between 0 and 1
+        UseGPU = false % Flag to compute vertices on the GPU
+    end
+    methods
+        function obj = Boxel(position, sz, color)
+            if nargin < 1
+                position = [0 0 0];
+            end
+            if nargin < 2
+                sz = [1 1 1];
+            end
+            if nargin < 3
+                color = [0.5 0.5 0.5];
+            end
+            obj.Position = position;
+            obj.Size = sz;
+            obj.Color = color;
+        end
+
+        function h = draw(obj, ax)
+            % draw Renders the boxel as a patch object in the provided axes.
+            %
+            %   h = draw(obj, ax) draws the boxel using the axes handle ax and
+            %   returns the patch handle h.
+            if nargin < 2 || isempty(ax)
+                ax = gca;
+            end
+
+            verts = obj.vertices();
+
+            if obj.UseGPU && gpuDeviceCount > 0
+                verts = gpuArray(verts); %#ok<GPUARRAY>
+                verts = gather(verts);
+            end
+
+            h = patch(ax, 'Vertices', verts, ...
+                'Faces', obj.faces(), ...
+                'FaceColor', obj.Color, 'EdgeColor', 'none');
+        end
+
+        function verts = vertices(obj)
+            % vertices Returns an 8x3 matrix of cuboid vertices in world coordinates.
+            [X, Y, Z] = obj.cuboidData();
+            verts = [X(:) Y(:) Z(:)];
+        end
+
+        function verts = localVertices(obj)
+            % localVertices Returns vertices relative to the object origin.
+            c = obj.Position - obj.Size/2;
+            X = [0 1 1 0 0 1 1 0]*obj.Size(1) + c(1);
+            Y = [0 0 1 1 0 0 1 1]*obj.Size(2) + c(2);
+            Z = [0 0 0 0 1 1 1 1]*obj.Size(3) + c(3);
+            if obj.UseGPU && gpuDeviceCount > 0
+                X = gpuArray(X); Y = gpuArray(Y); Z = gpuArray(Z); %#ok<GPUARRAY>
+                X = gather(X); Y = gather(Y); Z = gather(Z);
+            end
+            verts = [X(:) Y(:) Z(:)];
+        end
+
+        function F = faces(obj)
+            % faces Returns the face indices for the cuboid.
+            F = obj.cuboidFaces();
+        end
+    end
+
+    methods (Access = private)
+        function [X, Y, Z] = cuboidData(obj)
+            % cuboidData Generates vertices for the cuboid.
+            c = obj.Position - obj.Size/2;
+            X = [0 1 1 0 0 1 1 0]*obj.Size(1) + c(1);
+            Y = [0 0 1 1 0 0 1 1]*obj.Size(2) + c(2);
+            Z = [0 0 0 0 1 1 1 1]*obj.Size(3) + c(3);
+            if obj.UseGPU && gpuDeviceCount > 0
+                X = gpuArray(X); Y = gpuArray(Y); Z = gpuArray(Z); %#ok<GPUARRAY>
+                X = gather(X); Y = gather(Y); Z = gather(Z);
+            end
+        end
+
+        function F = cuboidFaces(~)
+            % cuboidFaces Returns face indices for a cuboid.
+            F = [1 2 3 4; 5 6 7 8; 1 2 6 5; 2 3 7 6; 3 4 8 7; 4 1 5 8];
+        end
+    end
+end

--- a/Source/Graphics/Building3D.m
+++ b/Source/Graphics/Building3D.m
@@ -1,0 +1,21 @@
+%{
+@file Building3D.m
+@brief Simple example object representing a building constructed from Boxels.
+%}
+
+classdef Building3D < Object3D
+    methods
+        function obj = Building3D(position, width, depth, height, color)
+            if nargin < 5
+                color = [0.8 0.8 0.8];
+            end
+            obj@Object3D(Boxel.empty, false, false);
+            nFloors = max(1, round(height));
+            for f = 1:nFloors
+                b = Boxel([0 0 (f-0.5)], [width depth 1], color);
+                obj.addBoxel(b);
+            end
+            obj.Position = position;
+        end
+    end
+end

--- a/Source/Graphics/GraphicsWindow.m
+++ b/Source/Graphics/GraphicsWindow.m
@@ -1,0 +1,84 @@
+%{
+@file GraphicsWindow.m
+@brief Provides a window for rendering a World3D scene and running animations.
+%}
+
+classdef GraphicsWindow < handle
+    properties
+        World % World3D instance to render
+        Figure
+        Axes
+        UseGPU = false
+        UseParallel = false
+    end
+
+    methods
+        function obj = GraphicsWindow(world, useGPU, useParallel)
+            if nargin < 1 || isempty(world)
+                obj.World = World3D();
+            else
+                obj.World = world;
+            end
+            if nargin < 2
+                useGPU = false;
+            end
+            if nargin < 3
+                useParallel = false;
+            end
+            obj.UseGPU = useGPU;
+            obj.UseParallel = useParallel;
+            obj.World.UseGPU = useGPU;
+            obj.World.UseParallel = useParallel;
+            obj.Figure = figure('Name','VDSS 3D View');
+            obj.Axes = axes('Parent', obj.Figure);
+            axis(obj.Axes,'equal');
+            view(obj.Axes,3);
+            grid(obj.Axes,'on');
+            xlabel(obj.Axes,'X'); ylabel(obj.Axes,'Y'); zlabel(obj.Axes,'Z');
+            rotate3d(obj.Figure,'on');
+            set(obj.Figure,'WindowScrollWheelFcn',@(src,evt)obj.scrollZoom(evt));
+        end
+
+        function render(obj)
+            cla(obj.Axes);
+            if ~isempty(obj.World)
+                obj.World.UseGPU = obj.UseGPU;
+                obj.World.UseParallel = obj.UseParallel;
+                obj.World.draw(obj.Axes);
+            end
+            drawnow;
+        end
+
+        function animate(obj, updateFcn, steps, dt)
+            if nargin < 4 || isempty(dt)
+                dt = 0.05;
+            end
+            if nargin < 3 || isempty(steps)
+                steps = 1;
+            end
+            for k = 1:steps
+                if nargin >= 2 && ~isempty(updateFcn)
+                    updateFcn(k);
+                end
+                obj.render();
+                pause(dt);
+            end
+        end
+
+        function zoomIn(obj)
+            camzoom(obj.Axes, 1.2);
+        end
+
+        function zoomOut(obj)
+            camzoom(obj.Axes, 0.8);
+        end
+
+        function scrollZoom(obj, evt)
+            if evt.VerticalScrollCount > 0
+                camzoom(obj.Axes, 1.1);
+            else
+                camzoom(obj.Axes, 0.9);
+            end
+        end
+    end
+end

--- a/Source/Graphics/Object3D.m
+++ b/Source/Graphics/Object3D.m
@@ -1,0 +1,198 @@
+%{
+@file Object3D.m
+@brief Combines multiple Boxel objects into a single drawable graphic.
+%}
+
+classdef Object3D
+    properties
+        Boxels = Boxel.empty
+        Position = [0 0 0]
+        Orientation = eye(3)
+        UseGPU = false
+        UseParallel = false
+    end
+
+    methods
+        function obj = Object3D(boxels, useGPU, useParallel)
+            if nargin < 1
+                boxels = Boxel.empty;
+            end
+            if nargin < 2
+                useGPU = false;
+            end
+            if nargin < 3
+                useParallel = false;
+            end
+            obj.Boxels = boxels;
+            obj.UseGPU = useGPU;
+            obj.UseParallel = useParallel;
+        end
+
+        function verts = localVertices(obj)
+            % localVertices Returns all transformed vertices of the object.
+            %   This utility exposes the vertex collection used internally
+            %   for mesh generation so that external code can query the
+            %   object geometry. Vertices are returned in world
+            %   coordinates accounting for the object's position and
+            %   orientation.
+
+            verts = obj.collectMesh();
+        end
+
+        function addBoxel(obj, boxel)
+            if obj.UseGPU
+                boxel.UseGPU = true;
+            end
+            obj.Boxels(end+1) = boxel;
+        end
+
+        function setOrientation(obj, yaw, pitch, roll)
+            % setOrientation Sets the object orientation.
+            %   Accepts yaw, pitch, roll angles (rad) or a 3x3 rotation
+            %   matrix when supplied as a single argument.  Any other input
+            %   sizes are rejected to avoid invalid states that can lead to
+            %   matrix dimension errors during rendering.
+
+            if nargin == 2 && ismatrix(yaw)
+                if all(size(yaw) == [3 3])
+                    obj.Orientation = yaw;
+                else
+                    error('Object3D:InvalidOrientation', ...
+                        'Orientation matrix must be 3x3.');
+                end
+                return;
+            end
+
+            if nargin < 4, roll = 0; end
+            if nargin < 3, pitch = 0; end
+            if nargin < 2, yaw = 0; end
+            Rz = [cos(yaw) -sin(yaw) 0; sin(yaw) cos(yaw) 0; 0 0 1];
+            Ry = [cos(pitch) 0 sin(pitch); 0 1 0; -sin(pitch) 0 cos(pitch)];
+            Rx = [1 0 0; 0 cos(roll) -sin(roll); 0 sin(roll) cos(roll)];
+            obj.Orientation = Rz*Ry*Rx;
+        end
+
+        function h = draw(obj, ax)
+            % draw Renders the composed object by drawing each boxel.
+            if nargin < 2 || isempty(ax)
+                ax = gca;
+            end
+            holdState = ishold(ax);
+            hold(ax, 'on');
+            n = numel(obj.Boxels);
+            vertsCell = cell(1,n);
+            facesCell = cell(1,n);
+            colorCell = cell(1,n);
+            boxels = obj.Boxels;
+            R = obj.Orientation;
+            pos = obj.Position;
+            useGPU = obj.UseGPU && gpuDeviceCount > 0;
+            if obj.UseParallel && ~isempty(gcp('nocreate'))
+                parfor i = 1:n
+                    b = boxels(i);
+                    v = b.localVertices();
+                    if useGPU
+                        v = gpuArray(v); %#ok<GPUARRAY>
+                        Rg = gpuArray(R); %#ok<GPUARRAY>
+                        v = (Rg * v.').';
+                        v = v + gpuArray(pos);
+                        v = gather(v);
+                    else
+                        v = (R * v.').';
+                        v = v + pos;
+                    end
+                    vertsCell{i} = v;
+                    facesCell{i} = b.faces();
+                    colorCell{i} = b.Color;
+                end
+            else
+                for i = 1:n
+                    b = boxels(i);
+                    v = b.localVertices();
+                    if useGPU
+                        v = gpuArray(v); %#ok<GPUARRAY>
+                        Rg = gpuArray(R); %#ok<GPUARRAY>
+                        v = (Rg * v.').';
+                        v = v + gpuArray(pos);
+                        v = gather(v);
+                    else
+                        v = (R * v.').';
+                        v = v + pos;
+                    end
+                    vertsCell{i} = v;
+                    facesCell{i} = b.faces();
+                    colorCell{i} = b.Color;
+                end
+            end
+
+            for i = 1:n
+                patch(ax, 'Vertices', vertsCell{i}, 'Faces', facesCell{i}, ...
+                    'FaceColor', colorCell{i}, 'EdgeColor', 'none');
+            end
+            if ~holdState
+                hold(ax, 'off');
+            end
+            h = []; % return handle array in future
+        end
+
+        function h = smoothSurface(obj, ax, alpha)
+            % smoothSurface Draws a smoothed version of the composed object.
+            %   This function computes an alpha shape of all vertices
+            %   from the contained boxels to produce a smoother looking
+            %   surface. A patch handle is returned.
+
+            if nargin < 2 || isempty(ax)
+                ax = gca;
+            end
+            if nargin < 3
+                alpha = 1.5;
+            end
+
+            [facesS, vertsS] = obj.getSmoothedMesh(alpha);
+            h = patch(ax, 'Vertices', vertsS, 'Faces', facesS, ...
+                'FaceColor', 'interp', 'EdgeColor', 'none');
+        end
+
+        function [facesS, vertsS] = getSmoothedMesh(obj, alpha)
+            % getSmoothedMesh Computes a smoothed mesh from all boxel vertices
+            if nargin < 2
+                alpha = 1.5;
+            end
+            verts = obj.collectMesh();
+            shp = alphaShape(verts, alpha);
+            [facesS, vertsS] = boundaryFacets(shp);
+        end
+    end
+
+    methods (Access = private)
+        function verts = collectMesh(obj)
+            % collectMesh Collects transformed vertices from all boxels
+            n = numel(obj.Boxels);
+            if n == 0
+                verts = zeros(0,3);
+                return;
+            end
+            vertsCell = cell(1,n);
+            R = obj.Orientation;
+            pos = obj.Position;
+            if obj.UseParallel && ~isempty(gcp('nocreate'))
+                parfor i = 1:n
+                    b = obj.Boxels(i);
+                    v = b.localVertices();
+                    v = (R * v.').';
+                    v = v + pos;
+                    vertsCell{i} = v; %#ok<PFOUS>
+                end
+            else
+                for i = 1:n
+                    b = obj.Boxels(i);
+                    v = b.localVertices();
+                    v = (R * v.').';
+                    v = v + pos;
+                    vertsCell{i} = v;
+                end
+            end
+            verts = vertcat(vertsCell{:});
+        end
+    end
+end

--- a/Source/Graphics/Road3D.m
+++ b/Source/Graphics/Road3D.m
@@ -1,0 +1,18 @@
+%{
+@file Road3D.m
+@brief Simple road segment constructed from a single Boxel.
+%}
+
+classdef Road3D < Object3D
+    methods
+        function obj = Road3D(startPos, len, width, color)
+            if nargin < 4
+                color = [0.2 0.2 0.2];
+            end
+            obj@Object3D(Boxel.empty, false, false);
+            b = Boxel([len/2 0 0], [len width 0.1], color);
+            obj.addBoxel(b);
+            obj.Position = startPos;
+        end
+    end
+end

--- a/Source/Graphics/Sim3DAnimator.m
+++ b/Source/Graphics/Sim3DAnimator.m
@@ -1,0 +1,53 @@
+%{
+@file Sim3DAnimator.m
+@brief Animates simulation results using the 3D graphics framework.
+%}
+
+classdef Sim3DAnimator < handle
+    properties
+        DataManager
+        GraphicsWindow
+        Truck
+        Steps
+        TractorParams
+        TrailerParams
+    end
+
+    methods
+        function obj = Sim3DAnimator(dataManager, graphicsWindow, truck, tractorParams, trailerParams)
+            if nargin < 2 || isempty(graphicsWindow)
+                graphicsWindow = GraphicsWindow();
+            end
+            obj.DataManager = dataManager;
+            obj.GraphicsWindow = graphicsWindow;
+            obj.Steps = numel(dataManager.globalVehicle1Data.X);
+            obj.TractorParams = tractorParams;
+            obj.TrailerParams = trailerParams;
+
+            if nargin >= 3 && ~isempty(truck)
+                obj.Truck = truck;
+            else
+                obj.Truck = Truck3D(tractorParams, trailerParams, graphicsWindow.UseGPU, graphicsWindow.UseParallel);
+            end
+            obj.Truck.addToWorld(obj.GraphicsWindow.World);
+        end
+
+        function run(obj, dt)
+            if nargin < 2
+                dt = obj.DataManager.dt;
+            end
+            for k = 1:obj.Steps
+                obj.updateVehicles(k);
+                obj.GraphicsWindow.render();
+                pause(dt);
+            end
+        end
+
+        function updateVehicles(obj, k)
+            if k > obj.Steps
+                return;
+            end
+            obj.Truck.update(obj.DataManager, k);
+        end
+    end
+end

--- a/Source/Graphics/Tire3D.m
+++ b/Source/Graphics/Tire3D.m
@@ -1,0 +1,37 @@
+%{
+@file Tire3D.m
+@brief Vehicle tire composed of multiple Boxels forming a ring.
+%}
+
+classdef Tire3D < VehiclePart3D
+    methods
+        function obj = Tire3D(radius, width, color, nSegments, useGPU, useParallel)
+            if nargin < 4
+                nSegments = 12;
+            end
+            if nargin < 3
+                color = [0 0 0];
+            end
+            if nargin < 2
+                width = 0.3;
+            end
+            if nargin < 1
+                radius = 0.5;
+            end
+            if nargin < 5
+                useGPU = false;
+            end
+            if nargin < 6
+                useParallel = false;
+            end
+            obj@VehiclePart3D('Tire', Boxel.empty, useGPU, useParallel);
+            for k = 1:nSegments
+                ang = 2*pi*(k-1)/nSegments;
+                pos = [radius*cos(ang) radius*sin(ang) 0];
+                segSize = [width radius*2*sin(pi/nSegments) radius*2*sin(pi/nSegments)];
+                b = Boxel(pos + [0 0 segSize(3)/2], segSize, color);
+                obj.addBoxel(b);
+            end
+        end
+    end
+end

--- a/Source/Graphics/Tractor3D.m
+++ b/Source/Graphics/Tractor3D.m
@@ -1,0 +1,32 @@
+%{
+@file Tractor3D.m
+@brief Simple tractor body built from Boxels.
+%}
+
+classdef Tractor3D < VehiclePart3D
+    methods
+        function obj = Tractor3D(length, width, height, color, useGPU, useParallel)
+            if nargin < 4
+                color = [1 0 0];
+            end
+            if nargin < 3
+                height = 1.5;
+            end
+            if nargin < 2
+                width = 1.0;
+            end
+            if nargin < 1
+                length = 3.0;
+            end
+            if nargin < 5
+                useGPU = false;
+            end
+            if nargin < 6
+                useParallel = false;
+            end
+            obj@VehiclePart3D('Tractor', Boxel.empty, useGPU, useParallel);
+            b = Boxel([length/2 0 height/2], [length width height], color);
+            obj.addBoxel(b);
+        end
+    end
+end

--- a/Source/Graphics/Trailer3D.m
+++ b/Source/Graphics/Trailer3D.m
@@ -1,0 +1,32 @@
+%{
+@file Trailer3D.m
+@brief Simple trailer body built from Boxels.
+%}
+
+classdef Trailer3D < VehiclePart3D
+    methods
+        function obj = Trailer3D(length, width, height, color, useGPU, useParallel)
+            if nargin < 4
+                color = [0 0 1];
+            end
+            if nargin < 3
+                height = 2.5;
+            end
+            if nargin < 2
+                width = 1.0;
+            end
+            if nargin < 1
+                length = 6.0;
+            end
+            if nargin < 5
+                useGPU = false;
+            end
+            if nargin < 6
+                useParallel = false;
+            end
+            obj@VehiclePart3D('Trailer', Boxel.empty, useGPU, useParallel);
+            b = Boxel([length/2 0 height/2], [length width height], color);
+            obj.addBoxel(b);
+        end
+    end
+end

--- a/Source/Graphics/Truck3D.m
+++ b/Source/Graphics/Truck3D.m
@@ -1,0 +1,77 @@
+%{
+@file Truck3D.m
+@brief Assembles a tractor and trailer into a single truck for 3D animation.
+%}
+
+classdef Truck3D < handle
+    properties
+        Tractor Vehicle3D
+        Trailer Vehicle3D
+        UseGPU = false
+        UseParallel = false
+        TractorParams
+        TrailerParams
+    end
+    methods
+        function obj = Truck3D(tractorParams, trailerParams, useGPU, useParallel)
+            if nargin < 4, useParallel = false; end
+            if nargin < 3, useGPU = false; end
+            obj.UseGPU = useGPU;
+            obj.UseParallel = useParallel;
+            obj.TractorParams = tractorParams;
+            obj.TrailerParams = trailerParams;
+            obj.Tractor = Vehicle3D(tractorParams, [1 0 0], useGPU, useParallel);
+            if nargin >= 2 && ~isempty(trailerParams)
+                obj.Trailer = Vehicle3D(trailerParams, [0 0 1], useGPU, useParallel);
+            end
+        end
+
+        function addToWorld(obj, world)
+            world.addObject(obj.Tractor.Body);
+            for t = obj.Tractor.Tires
+                world.addObject(t);
+            end
+            if ~isempty(obj.Trailer)
+                world.addObject(obj.Trailer.Body);
+                for t = obj.Trailer.Tires
+                    world.addObject(t);
+                end
+            end
+        end
+
+        function update(obj, dataManager, step)
+            xT = dataManager.globalVehicle1Data.X(step);
+            yT = dataManager.globalVehicle1Data.Y(step);
+            thT = dataManager.globalVehicle1Data.Theta(step);
+            obj.Tractor.setState(xT, yT, thT);
+            if ~isempty(obj.Trailer)
+                vParams = obj.TractorParams;
+                tParams = obj.TrailerParams;
+                axSp = vParams.axleSpacing;
+                len = vParams.length;
+                numAx = vParams.numAxles;
+                midIdx = ceil(numAx/2);
+                frontOff = len/2;
+                midOff = midIdx * axSp;
+                xFront = xT + frontOff * cos(thT);
+                yFront = yT + frontOff * sin(thT);
+                xMid = xFront - midOff * cos(thT);
+                yMid = yFront - midOff * sin(thT);
+                hDist = tParams.HitchDistance;
+                hitchX = xMid - hDist * cos(thT) - (vParams.axleSpacing/2)*cos(thT);
+                hitchY = yMid - hDist * sin(thT) - (vParams.axleSpacing/2)*sin(thT);
+                relTheta = dataManager.globalTrailer1Data.Theta(step);
+                absTheta = thT + relTheta;
+                obj.Trailer.setState(hitchX, hitchY, absTheta);
+            end
+        end
+
+        function drawMeshes(obj, ax)
+            if nargin < 2, ax = gca; end
+            obj.Tractor.drawMesh(ax);
+            if ~isempty(obj.Trailer)
+                obj.Trailer.drawMesh(ax);
+            end
+        end
+    end
+end

--- a/Source/Graphics/Vehicle3D.m
+++ b/Source/Graphics/Vehicle3D.m
@@ -1,0 +1,66 @@
+%{
+@file Vehicle3D.m
+@brief Generic vehicle built from boxels and tires based on 2D plotting parameters.
+%}
+
+classdef Vehicle3D < handle
+    properties
+        Body   % Object3D representing the main body
+        Tires  % array of Tire3D objects
+        Params % struct of vehicle parameters from 2D plot
+        UseGPU = false
+        UseParallel = false
+    end
+    methods
+        function obj = Vehicle3D(params, bodyColor, useGPU, useParallel)
+            if nargin < 4
+                useParallel = false;
+            end
+            if nargin < 3
+                useGPU = false;
+            end
+            if nargin < 2 || isempty(bodyColor)
+                bodyColor = [0.8 0.2 0.2];
+            end
+            obj.Params = params;
+            obj.UseGPU = useGPU;
+            obj.UseParallel = useParallel;
+            obj.Body = VehiclePart3D('Body', Boxel.empty, useGPU, useParallel);
+            b = Boxel([params.length/2 0 params.height/2], ...
+                [params.length params.width params.height], bodyColor);
+            obj.Body.addBoxel(b);
+            obj.Tires = Tire3D.empty;
+            axlePositions = linspace(-params.length/2 + params.axleSpacing, ...
+                                     params.length/2 - params.axleSpacing, ...
+                                     params.numAxles);
+            for i = 1:numel(axlePositions)
+                pos = axlePositions(i);
+                tL = Tire3D(params.wheelHeight/2, params.wheelWidth, [0 0 0], 12, useGPU, useParallel);
+                tL.Position = [pos params.trackWidth/2 params.wheelHeight/2];
+                obj.Tires(end+1) = tL;
+                tR = Tire3D(params.wheelHeight/2, params.wheelWidth, [0 0 0], 12, useGPU, useParallel);
+                tR.Position = [pos -params.trackWidth/2 params.wheelHeight/2];
+                obj.Tires(end+1) = tR;
+            end
+        end
+
+        function setState(obj, x, y, theta)
+            obj.Body.Position = [x y 0];
+            obj.Body.setOrientation(theta);
+            R = obj.Body.Orientation;
+            for i = 1:numel(obj.Tires)
+                off = obj.Tires(i).Position;
+                obj.Tires(i).Position = [x y 0] + (R * off.').';
+                obj.Tires(i).setOrientation(theta);
+            end
+        end
+
+        function drawMesh(obj, ax)
+            if nargin < 2, ax = gca; end
+            obj.Body.smoothSurface(ax);
+            for i = 1:numel(obj.Tires)
+                obj.Tires(i).smoothSurface(ax);
+            end
+        end
+    end
+end

--- a/Source/Graphics/VehiclePart3D.m
+++ b/Source/Graphics/VehiclePart3D.m
@@ -1,0 +1,28 @@
+%{
+@file VehiclePart3D.m
+@brief Base class for vehicle parts composed of Boxel objects.
+%}
+
+classdef VehiclePart3D < Object3D
+    properties
+        Name
+    end
+    methods
+        function obj = VehiclePart3D(name, boxels, useGPU, useParallel)
+            if nargin < 1
+                name = '';
+            end
+            if nargin < 2
+                boxels = Boxel.empty;
+            end
+            if nargin < 3
+                useGPU = false;
+            end
+            if nargin < 4
+                useParallel = false;
+            end
+            obj@Object3D(boxels, useGPU, useParallel);
+            obj.Name = name;
+        end
+    end
+end

--- a/Source/Graphics/World3D.m
+++ b/Source/Graphics/World3D.m
@@ -1,0 +1,51 @@
+%{
+@file World3D.m
+@brief Manages and draws a collection of Object3D instances to form a scene.
+%}
+
+classdef World3D < handle
+    properties
+        Objects = Object3D.empty
+        CameraPosition = [10 10 10]
+        CameraTarget = [0 0 0]
+        UseGPU = false
+        UseParallel = false
+    end
+
+    methods
+        function addObject(obj, object3d)
+            if obj.UseGPU
+                object3d.UseGPU = true;
+            end
+            if obj.UseParallel && isprop(object3d, 'UseParallel')
+                object3d.UseParallel = true;
+            end
+            obj.Objects(end+1) = object3d;
+        end
+
+        function clear(obj)
+            obj.Objects = Object3D.empty;
+        end
+
+        function draw(obj, ax)
+            % draw Renders all objects in the world.
+            if nargin < 2 || isempty(ax)
+                ax = gca;
+            end
+            view(ax, 3);
+            grid(ax, 'on');
+            holdState = ishold(ax);
+            hold(ax, 'on');
+            for i = 1:numel(obj.Objects)
+                obj.Objects(i).draw(ax);
+            end
+            if ~holdState
+                hold(ax, 'off');
+            end
+            xlabel(ax,'X'); ylabel(ax,'Y'); zlabel(ax,'Z');
+            camproj(ax,'perspective');
+            campos(ax, obj.CameraPosition);
+            camtarget(ax, obj.CameraTarget);
+        end
+    end
+end

--- a/VDSS.m
+++ b/VDSS.m
@@ -488,6 +488,22 @@ function VDSS
     % */
     function startSimulation()
         simulationManager.runSimulations();
+        try
+            gw = GraphicsWindow(World3D(), true, true);
+            tractorParams1 = simulationManager.createVehicleParams(vehicleSim1.simParams, ...
+                vehicleSim1.simParams.tractorTireHeight, vehicleSim1.simParams.tractorTireWidth);
+            if vehicleSim1.simParams.includeTrailer
+                trailerParams1 = simulationManager.createTrailerParams(vehicleSim1.simParams, ...
+                    vehicleSim1.simParams.trailerTireHeight, vehicleSim1.simParams.trailerTireWidth, 1);
+            else
+                trailerParams1 = [];
+            end
+            truck = Truck3D(tractorParams1, trailerParams1, true, true);
+            animator = Sim3DAnimator(dataManager, gw, truck, tractorParams1, trailerParams1);
+            animator.run();
+        catch ME
+            disp(['3D Animation failed: ' ME.message]);
+        end
     end
     
     %/**


### PR DESCRIPTION
## Summary
- support parallel rendering in `Object3D`
- propagate `UseParallel` flag through world and graphics classes
- construct trucks and graphics window with GPU+parallel enabled
- update smoothed mesh collection to run in parfor loops
- add `Object3D.localVertices` helper
- fix orientation argument handling to avoid invalid matrices
- validate orientation matrix size to prevent math errors
- add Python 3D graphics framework for easy vehicle rendering

## Testing
- `matlab -batch "runtests('tests')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6848184d563c832794af9d43448734f9