### PR TITLE
Fix traction scaling with mass

### DIFF
--- a/Source/Physics/ForceCalculator.m
+++ b/Source/Physics/ForceCalculator.m
@@ -1153,7 +1153,27 @@ classdef ForceCalculator
 
         %% updateTractionForce
         function obj = updateTractionForce(obj, F_traction)
-            tractionForce= [F_traction;0;0];
+            % updateTractionForce Apply longitudinal traction force with
+            % friction limit.
+
+            % Compute maximum available traction based on the normal load of
+            % the driven tractor tires.  This prevents unrealistically large
+            % accelerations when trailer mass increases.
+            if ~isempty(obj.loadDistribution)
+                loads = obj.loadDistribution(:,4);
+                if strcmp(obj.vehicleType, 'tractor-trailer') || strcmp(obj.vehicleType, 'tractor')
+                    nTractorTires = size(obj.loadDistribution,1) - obj.numTrailerTires;
+                    loads = loads(1:nTractorTires);
+                end
+                maxTraction = sum(loads) * obj.frictionCoefficient;
+            else
+                maxTraction = abs(F_traction); % no information -> no limit
+            end
+
+            % Clamp traction force within [-maxTraction, maxTraction]
+            F_traction = min(max(F_traction, -maxTraction), maxTraction);
+
+            tractionForce = [F_traction;0;0];
             obj.calculatedForces.traction = tractionForce;
             obj.calculatedForces.traction_force = tractionForce;
         end

--- a/tests/TractionLimitTest.m
+++ b/tests/TractionLimitTest.m
@@ -1,0 +1,15 @@
+function tests = TractionLimitTest
+    tests = functiontests(localfunctions);
+end
+
+function testTractionClamped(testCase)
+    loadDist = [1 1 0 5000 0.1; -1 -1 0 5000 0.1];
+    tireModel = PacejkaMagicFormula(10,1.9,8000,0.97);
+    susp = LeafSpringSuspension(1000,100,0.3,1000,2,3);
+    brake = BrakeSystem();
+    fc = ForceCalculator('tractor', 1000, 0.8, [0;0;0], 0.3, 1.2, 1, 1, 0.8, Inf, ...
+        loadDist, [0;0;0], 1, [0;0;0], 0, 2, 3, tireModel, susp, 0, 0.01, 0, 0, 0, [], [], 'simple', [], [0;0;0], brake);
+    fc = fc.updateTractionForce(20000); % exceed mu*load -> should clamp
+    forces = fc.getCalculatedForces();
+    verifyLessThanOrEqual(testCase, forces.traction(1), 8000 + 1e-10);
+end


### PR DESCRIPTION
## Summary
- limit traction force in `ForceCalculator` by available friction
- test that traction force is clamped by normal load

## Testing
- `matlab -batch "disp('test')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684e1eadcbac8327abe9170acf317bb0