### PR TITLE
Fix misformatted table diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,7 +611,9 @@ is loaded into the relevant mechanical block or controller at simulation start.
 |`pCx1..pKy3`|Pacejka Coefficients|Tire Model|Pacejka tire model coefficients.|
 |`spinnerConfigs`|Spinner Configs|Stiffness & Damping|Spinner graphics config.|
 |`mapCommands`|Map Commands|Mapping|Map creation string.|
-|`waypoints`|Waypoints|Path Follower|Explicit waypoint list.|```mermaid
+|`waypoints`|Waypoints|Path Follower|Explicit waypoint list.|
+
+```mermaid
 flowchart LR
   Basic --> VehicleModel
   Geometry --> VehicleModel


### PR DESCRIPTION
## Summary
- fix mermaid code block placement in parameter table

## Testing
- `runtests('tests')` *(fails: MATLAB/Octave not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68854343b9f8832594938a4c7bce7686