### PR TITLE
Add heavy vehicle J2980 extension docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ VDSS provides a MATLAB based environment for simulating vehicle dynamics and saf
 - [Mechanical Model Blocks](#mechanical-model-blocks)
 - [Physics Models](#physics-models)
 - [Physics](#physics)
+- [J2980 Extension for Heavy Vehicles](#j2980-extension-for-heavy-vehicles)
 
 ## Directory Structure
 - `Source/` – MATLAB toolboxes that implement the simulator.
@@ -960,3 +961,54 @@ $y_k = \alpha x_k + (1-\alpha) y_{k-1}$
 Tuning parameters like $r_{\max}$, window size $N$ and coefficient $\alpha$
 are exposed in the GUI tabs so users can calibrate how aggressively commands are
 smoothed.
+
+## J2980 Extension for Heavy Vehicles
+The SAE&nbsp;J2980 crash severity tables assume a passenger vehicle mass of
+approximately 3000&nbsp;kg. To compare heavier vehicles such as fully loaded
+class&nbsp;8 trucks, VDSS scales the delta‑V thresholds so that the equivalent
+kinetic energy is matched.
+
+### Energy-Based Scaling
+For each delta‑V value $\Delta v_{car}$ from the original table we first
+compute the kinetic energy it represents:
+
+$$
+E = \tfrac{1}{2} m_{car} \left(\tfrac{\Delta v_{car}}{3.6}\right)^2
+$$
+
+where $m_{car}$ is the maximum passenger‑vehicle mass in J2980
+(3000&nbsp;kg). To find the equivalent delta‑V for a heavy vehicle of mass
+$m_{hv}$ the same energy is used:
+
+$$
+\Delta v_{hv} = 3.6\sqrt{\tfrac{2E}{m_{hv}}}
+$$
+
+This simplifies to a scaling factor
+$$
+\Delta v_{hv} = \Delta v_{car} \sqrt{\tfrac{m_{car}}{m_{hv}}}
+$$
+
+### Calculation Flow
+
+```mermaid
+flowchart TD
+    dv["ΔV from J2980"] --> ke["KE = 0.5 * m_car * (ΔV / 3.6)^2"]
+    mass["Truck mass"] --> scaled["ΔV_hv = 3.6 * sqrt(2 * KE / m_hv)"]
+    ke --> scaled
+```
+
+### Extended Table for a Class 8 Truck
+Using a fully loaded mass of 36&nbsp;000&nbsp;kg the scaling factor is
+$$\sqrt{\tfrac{3000}{36000}} \approx 0.29$$
+The delta‑V thresholds for each collision type become:
+
+| Severity | Head-On ΔV (kph) | Rear-End ΔV (kph) | Side ΔV (kph) | Oblique ΔV (kph) |
+|---------|------------------|-------------------|---------------|------------------|
+| S0 | 0–2.0 | 0–2.0 | 0–0.7 | 0–1.4 |
+| S1 | 2.0–10.1 | 2.0–10.1 | 0.7–1.7 | 1.4–5.9 |
+| S2 | 10.1–15.2 | 10.1–15.2 | 1.7–11.3 | 5.9–13.7 |
+| S3 | >15.2 | >15.2 | >11.3 | >13.7 |
+
+These values allow the J2980 categories to be applied to heavy vehicles while
+preserving the equivalent kinetic energy threshold.


### PR DESCRIPTION
## Summary
- document J2980 extension for heavy vehicles in README
- fix mermaid diagram and include full table for class 8 truck
- format the heavy vehicle scaling formulas consistently

## Testing
- `matlab -batch "disp('hello')"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688596a4f5a883259f5f69edbb01c06c