### PR TITLE
Fix README latex macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,13 +504,13 @@ flowchart LR
   path ahead for a target point.  The heading error is
 
   $$\[
-  \alpha = \operatorname{atan2}(y_l - \hat{p}_y,\; x_l - \hat{p}_x) - \hat{\theta}
+  \alpha = \text{atan2}(y_l - \hat{p}_y,\; x_l - \hat{p}_x) - \hat{\theta}
   \]$$
 
   and the raw steering command becomes
 
   $$\[
-\delta_{pp} = \operatorname{atan2}(2L \sin \alpha,\; d_l)
+\delta_{pp} = \text{atan2}(2L \sin \alpha,\; d_l)
   \]$$
 
   `planPathWithPredictions` refines the trajectory and the result passes through Gaussian and low\-pass
@@ -551,7 +551,7 @@ $\hat{p} = p + v t_p[\cos\hat{\theta},\sin\hat{\theta}]$ represent the
 predicted heading and position after time $t_p$. From the predicted position
 the controller computes
 $$\[
-\alpha = \operatorname{atan2}(y_l - \hat{p}_y,\; x_l - \hat{p}_x) - \hat{\theta}
+\alpha = \text{atan2}(y_l - \hat{p}_y,\; x_l - \hat{p}_x) - \hat{\theta}
 \]$$
 and distance $d_l$ to the target waypoint. `planPathWithPredictions` then
 adjusts the reference path to eliminate zig\-zag oscillations before the
@@ -565,7 +565,7 @@ the predicted pose is available. Internally it:
    along upcoming segments until a point at least `lookaheadDistance` from the
    predicted position is found, interpolating between waypoints when necessary.
 2. **Computes heading error and curvature.** The heading error is
-   $\alpha = \operatorname{atan2}(y_l - \hat{p}_y,\; x_l - \hat{p}_x) - \hat{\theta}$.
+   $\alpha = \text{atan2}(y_l - \hat{p}_y,\; x_l - \hat{p}_x) - \hat{\theta}$.
    Curvature follows as
    $\kappa = 2 \sin(\alpha) / \text{lookaheadDistance}$ and the raw steering
    request is $\delta_{raw} = \tan^{-1}(\text{wheelbase} \times \kappa)$
@@ -658,7 +658,7 @@ flowchart LR
 
 The algorithm picks the first waypoint at distance $d$ ahead of the vehicle and computes
 $$\[
-\alpha = \operatorname{atan2}(y_l - p_y,\; x_l - p_x) - \theta.
+\alpha = \text{atan2}(y_l - p_y,\; x_l - p_x) - \theta.
 \]$$
 
 ###### Compute Curvature


### PR DESCRIPTION
## Summary
- replace `\operatorname` uses with `\text` to satisfy KaTeX restrictions

## Testing
- `which matlab`

------
https://chatgpt.com/codex/tasks/task_b_6885c08c8b60832598f64cbbdd601f29