### PR TITLE
Fix formulas by removing stray spacing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,9 +566,9 @@ flowchart LR
   - $\hat{\theta}$ – predicted heading
   - $\hat{p}$ – predicted position
 
-  $$
-  \alpha = \text{atan2}(y_l - \hat{p}_y,\; x_l - \hat{p}_x) - \hat{\theta}
-  \]$$
+$$
+\alpha = \operatorname{atan2}(y_l - \hat{p}_y, x_l - \hat{p}_x) - \hat{\theta}
+$$
   Parameters:
   - $y_l, x_l$ – coordinates of the lookahead point (m)
   - $\hat{p}_x, \hat{p}_y$ – predicted position components (m)
@@ -577,9 +577,9 @@ flowchart LR
 
   and the raw steering command becomes
 
-  $$
-\delta_{pp} = \text{atan2}(2L \sin \alpha,\; d_l)
-  \]$$
+$$
+\delta_{pp} = \operatorname{atan2}(2L \sin \alpha, d_l)
+$$
   Parameters:
   - $L$ – wheelbase (m)
   - $\alpha$ – heading error (rad)
@@ -628,7 +628,7 @@ $\hat{p} = p + v t_p[\cos\hat{\theta},\sin\hat{\theta}]$ represent the
 predicted heading and position after time $t_p$. From the predicted position
 the controller computes
 $$
-\alpha = \text{atan2}(y_l - \hat{p}_y,\; x_l - \hat{p}_x) - \hat{\theta}
+\alpha = \operatorname{atan2}(y_l - \hat{p}_y, x_l - \hat{p}_x) - \hat{\theta}
 $$
 and distance $d_l$ to the target waypoint. `planPathWithPredictions` then
 adjusts the reference path to eliminate zig\-zag oscillations before the
@@ -642,7 +642,7 @@ the predicted pose is available. Internally it:
    along upcoming segments until a point at least `lookaheadDistance` from the
    predicted position is found, interpolating between waypoints when necessary.
 2. **Computes heading error and curvature.** The heading error is
-   $\alpha = \text{atan2}(y_l - \hat{p}_y,\; x_l - \hat{p}_x) - \hat{\theta}$.
+   $\alpha = \operatorname{atan2}(y_l - \hat{p}_y, x_l - \hat{p}_x) - \hat{\theta}$.
    Curvature follows as
    $\kappa = 2 \sin(\alpha) / \text{lookaheadDistance}$ and the raw steering
    request is $\delta_{raw} = \tan^{-1}(\text{wheelbase} \times \kappa)$
@@ -735,7 +735,7 @@ flowchart LR
 
 The algorithm picks the first waypoint at distance $d$ ahead of the vehicle and computes
 $$
-\alpha = \text{atan2}(y_l - p_y,\; x_l - p_x) - \theta.
+\alpha = \operatorname{atan2}(y_l - p_y, x_l - p_x) - \theta.
 $$
 
 ###### Compute Curvature
@@ -758,7 +758,9 @@ flowchart LR
 *Input*: raw steering $\delta_{pp}$.
 *Output*: smoothed value $\delta_g$.
 
-$$\[\delta_g[k] = \sum_{i=-n}^n w_i\, \delta_{pp}[k-i]\]$$
+$$
+\delta_g[k] = \sum_{i=-n}^n w_i\, \delta_{pp}[k-i]
+$$
 Parameters:
   - $w_i$ – Gaussian weights
   - $\delta_{pp}[k-i]$ – raw steering samples
@@ -774,7 +776,9 @@ flowchart LR
 *Input*: smoothed command $\delta_g$.
 *Output*: filtered steering angle $\delta$.
 
-$$\[\delta[k] = \alpha_f \,\delta_g[k] + (1-\alpha_f)\,\delta[k-1]\]$$
+$$
+\delta[k] = \alpha_f \,\delta_g[k] + (1-\alpha_f)\,\delta[k-1]
+$$
 Parameters:
   - $\alpha_f$ – low-pass filter coefficient
   - $\delta_g[k]$ – current smoothed value


### PR DESCRIPTION
## Summary
- replace `\text{atan2}` with `\operatorname{atan2}` in README formulas
- remove extraneous spacing commands around function arguments

## Testing
- `make test` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_b_6886243af0d4832581163731a356080a