### PR TITLE
Add initial Python GUI skeleton

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,15 @@
+# VDSS Python GUI
+
+This directory contains the early Python implementation of the Vehicle Dynamics
+Safety Simulator user interface.  It mirrors the MATLAB prototype but focuses
+on a production-ready architecture with parallel execution in mind.
+
+The GUI is written with `tkinter` so it runs without external dependencies.  No
+backend model is provided yet; the window layout and asynchronous task queue are
+in place so computation-heavy modules can be integrated later.
+
+Run the GUI with:
+
+```bash
+python3 -m vdss_gui.main
+```

--- a/python/vdss_gui/main.py
+++ b/python/vdss_gui/main.py
@@ -1,0 +1,104 @@
+"""VDSS GUI - Python Implementation (Prototype)
+
+This module defines a basic Tkinter-based GUI skeleton for the
+Vehicle Dynamics Safety Simulator (VDSS) production version.
+It exposes only the user interface elements without
+backend logic. The design anticipates asynchronous
+execution so that simulation and data processing can run
+in parallel threads or processes later on.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+from dataclasses import dataclass
+from tkinter import Tk, ttk, Menu
+
+
+@dataclass
+class AppConfig:
+    """Configuration options for the VDSS GUI."""
+
+    title: str = "VDSS"
+    width: int = 1024
+    height: int = 768
+
+
+class VDSSApp:
+    """Main application window."""
+
+    def __init__(self, config: AppConfig | None = None) -> None:
+        self.config = config or AppConfig()
+        self.root = Tk()
+        self.root.title(self.config.title)
+        self.root.geometry(f"{self.config.width}x{self.config.height}")
+
+        # Message queue intended for background threads
+        self._queue: queue.Queue[str] = queue.Queue()
+        self._create_widgets()
+        self._poll_queue()
+
+    # ------------------------------------------------------------------
+    def _create_widgets(self) -> None:
+        self._create_menu()
+        self._create_tabs()
+
+    def _create_menu(self) -> None:
+        menu_bar = Menu(self.root)
+        file_menu = Menu(menu_bar, tearoff=0)
+        file_menu.add_command(label="Exit", command=self.root.quit)
+        menu_bar.add_cascade(label="File", menu=file_menu)
+        self.root.config(menu=menu_bar)
+
+    def _create_tabs(self) -> None:
+        notebook = ttk.Notebook(self.root)
+        notebook.pack(fill="both", expand=True)
+
+        # Simulation setup tab
+        self.setup_tab = ttk.Frame(notebook)
+        notebook.add(self.setup_tab, text="Setup")
+
+        # Vehicle configuration tab
+        self.vehicle_tab = ttk.Frame(notebook)
+        notebook.add(self.vehicle_tab, text="Vehicle")
+
+        # Run control tab
+        self.run_tab = ttk.Frame(notebook)
+        notebook.add(self.run_tab, text="Run")
+
+        # Results tab
+        self.results_tab = ttk.Frame(notebook)
+        notebook.add(self.results_tab, text="Results")
+
+    # ------------------------------------------------------------------
+    def _poll_queue(self) -> None:
+        """Check for messages from background workers."""
+        try:
+            while True:
+                msg = self._queue.get_nowait()
+                print(msg)  # Placeholder for future event handling
+        except queue.Empty:
+            pass
+        finally:
+            self.root.after(100, self._poll_queue)
+
+    # ------------------------------------------------------------------
+    def start_background_task(self, func: callable, *args, **kwargs) -> None:
+        """Launch ``func`` in a separate thread."""
+
+        def wrapper() -> None:
+            result = func(*args, **kwargs)
+            self._queue.put(str(result))
+
+        threading.Thread(target=wrapper, daemon=True).start()
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        """Start the GUI event loop."""
+        self.root.mainloop()
+
+
+# ----------------------------------------------------------------------
+if __name__ == "__main__":
+    VDSSApp().run()


### PR DESCRIPTION
## Summary
- add a `python` folder to host a production-oriented VDSS version
- create a Tkinter-based GUI placeholder with future async support
- document how to run the GUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6886339535b88325aae9154af03f3380