### PR TITLE
Set up cloud dev environment + AGENTS.md instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repository contains **two components**:
+
+1. **VDSS MATLAB simulator (primary product)** — `VDSS.m`, `Source/`, `Scripts/`,
+   `tests/`, `Curves/`, `codegen/`. A desktop scientific application (App Designer /
+   `uifigure` GUI, class-based toolboxes) for vehicle dynamics & crash-severity
+   simulation. There are no servers, ports, databases, or secrets.
+2. **Python Tkinter GUI prototype** — `python/vdss_gui/`. An early UI skeleton that
+   mirrors the MATLAB GUI. See `python/README.md`.
+
+### MATLAB simulator (requires licensed MATLAB — not available in the cloud VM)
+- The main product and its test suite need a **licensed MATLAB** install, which cannot
+  be installed via a package manager in this VM. Run steps are in `README.md`
+  (`addpath(genpath(pwd))`, then `VDSS`; tests via `runtests('tests')`).
+- Tests use the `matlab.unittest` framework (`functiontests` / `verifyEqual`) and the
+  GUI uses App Designer widgets, so **GNU Octave cannot run the tests or the GUI**.
+- **Octave (8.x) is pre-installed** as a convenience for sanity-checking *pure-numeric*
+  core algorithms only (e.g. `Source/Physics/VehicleCollisionSeverity.m` collision
+  dynamics). Caveat: Octave treats MATLAB double-quoted strings as `char` arrays, so
+  code that relies on the MATLAB `string` class (e.g. `"S" + num2str(...)` severity
+  labels) produces numeric results in Octave — do not trust those outputs. Octave is
+  **not** a substitute for MATLAB.
+  - Example: `octave --no-gui --quiet` then `addpath('Source/Physics')` and construct
+    `VehicleCollisionSeverity(...)`, call `PerformCollision()` / `CalculateSeverity()`.
+
+### Python GUI prototype (the runnable app in this VM)
+- Requires `python3-tk` (system package, pre-installed in the VM snapshot) plus an X
+  display. This VM exposes a desktop on `DISPLAY=:1`.
+- Run from the `python/` directory: `python3 -m vdss_gui.main`. If launching from
+  another directory, set `PYTHONPATH` to the `python/` folder.
+- It is a **skeleton**: the Setup/Vehicle/Run/Results tabs are intentionally empty
+  frames and there is no simulation backend yet. The implemented functionality is the
+  window/tab/menu layout plus an async background-task → `queue` → `_poll_queue`
+  pump (`start_background_task`). Blank tab content is expected, not a bug.
+- Uses only the Python standard library — there are no `pip` dependencies.
+
+### Dependencies
+- There are **no package-manager dependency files** (no `requirements.txt`,
+  `package.json`, etc.). The only environment needs are the system packages
+  `python3-tk` and `octave`, which are baked into the VM snapshot; the startup update
+  script is therefore effectively a no-op.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this repository in the Cursor Cloud VM and documents how to run each component. Adds an `AGENTS.md` with durable, non-obvious instructions for future agents. No product code was changed.

## What this repo contains
- **VDSS MATLAB simulator (primary product):** `VDSS.m`, `Source/`, `Scripts/`, `tests/`, `Curves/`, `codegen/`. Desktop scientific app (App Designer GUI + class-based toolboxes). No servers/ports/DB/secrets.
- **Python Tkinter GUI prototype:** `python/vdss_gui/` — an early UI skeleton (no backend yet).

## Environment setup
- Installed system packages `python3-tk` (needed by the Python GUI) and `octave` (for sanity-checking pure-numeric MATLAB algorithms). These are baked into the VM snapshot.
- There are **no package-manager dependency files** (no `requirements.txt`/`package.json`), so the startup update script is effectively a no-op (`python3 --version`).

## Scope note (MATLAB)
The primary product and its `matlab.unittest` test suite require a **licensed MATLAB** install, which cannot be provisioned in this Linux cloud VM. Octave cannot substitute for the tests (`functiontests`/`verifyEqual`) or the App Designer GUI, and treats MATLAB double-quoted strings as `char` arrays. This is documented in `AGENTS.md`.

## Demonstrated working end-to-end
| Component | How run | Result |
| --- | --- | --- |
| Python GUI (`python/vdss_gui`) | `python3 -m vdss_gui.main` (DISPLAY=:1) | Window launches; tabs + File menu interactive; async task-queue smoke test passes |
| Core MATLAB physics (Octave sanity check) | `octave` + `Source/Physics/VehicleCollisionSeverity.m` | Collision dynamics compute; momentum conserved (0 → 0); delta-V = 64.8 kph |

The GUI's four tabs are intentionally empty frames (skeleton has no backend/widgets yet, per `python/README.md`); blank tab content is expected.

## Artifacts
[vdss_python_gui_navigation_demo.mp4](https://cursor.com/agents/bc-b5a27958-c253-4fcc-ae0c-087f048ac508/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvdss_python_gui_navigation_demo.mp4)
[VDSS Python GUI Setup tab](https://cursor.com/agents/bc-b5a27958-c253-4fcc-ae0c-087f048ac508/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvdss_python_gui_setup_tab.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5a27958-c253-4fcc-ae0c-087f048ac508?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5a27958-c253-4fcc-ae0c-087f048ac508&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

